### PR TITLE
fix(app): ensure asserting the correct bytes on nonce check

### DIFF
--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -63,7 +63,7 @@ export class Database implements Loggable {
       .returning({
         id: schema.pending.id,
         expiration: schema.pending.expiration,
-        nonce: schema.pending.expiration,
+        nonce: schema.pending.nonce,
       })
       .then(assertSingle);
   }

--- a/src/routes/oauth/login/+server.js
+++ b/src/routes/oauth/login/+server.js
@@ -24,13 +24,7 @@ export async function GET({ locals: { db }, cookies, setHeaders, url: { searchPa
     expires: expiration,
   });
 
-  // TODO: Use more secure CSRF token. Hash the entire session details instead of the public session ID.
-  const hashedSessionId = await crypto.subtle.digest(
-    'SHA-256',
-    new TextEncoder().encode(sessionId),
-  );
   const params = new URLSearchParams({
-    state: Buffer.from(hashedSessionId).toString('base64url'),
     client_id: GOOGLE.OAUTH_CLIENT_ID,
     redirect_uri: GOOGLE.OAUTH_REDIRECT_URI,
     nonce: Buffer.from(nonce).toString('base64url'),


### PR DESCRIPTION
* This PR fixes #38. A typo in the database queries led us to yield `pending.expiration` instead of `pending.nonce`, hence the nonce mismatches.
* This PR also fixes several inconsistencies with the primary key migration of the `user` table from emails to ULIDs. Some call sites previously invoked the database helpers with an email instead of a ULID. As far as TypeScript was concerned, both were `string` types so these couldn't have been caught by the type checker. Now these call sites have been updated, but please do keep your eyes peeled in case we missed some.
* I've also removed the `state` checks in the OAuth 2.0 flow because these are redundant in the presence of the `nonce` checks that we already do anyway.