### PR TITLE
feat(hooks.server.ts): improve logging for errors

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -22,8 +22,13 @@ const logger = pino(stream);
 export async function handle({ event, resolve }) {
   const { cookies, locals, request } = event;
 
-  const requestLogger = logger.child({ requestId: crypto.randomUUID() });
-  requestLogger.info({ method: request.method, url: request.url });
+  const requestLogger = logger.child({ 
+    requestId: crypto.randomUUID(),
+    method: request.method,
+    url: request.url
+  });
+
+  requestLogger.info("request initiated");
 
   locals.db = Database.fromUrl(POSTGRES.URL, requestLogger);
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,9 +1,11 @@
+import { getDotPath, isValiError } from 'valibot';
 import type { PrettyStream } from 'pino-pretty';
 import { pino } from 'pino';
 
 import { dev } from '$app/environment';
 
 import * as POSTGRES from '$lib/server/env/postgres';
+import { AssertionError } from 'assert';
 import { Database } from '$lib/server/database';
 
 // eslint-disable-next-line @typescript-eslint/init-declarations
@@ -43,4 +45,17 @@ export async function handle({ event, resolve }) {
     locals.db.logger.error({ error, response_time: performance.now() - start });
     throw error;
   }
+}
+
+export function handleError({ error, event }) {
+    if (isValiError(error)) {
+        const valibotErrorPaths = error.issues.map(issue => getDotPath(issue)).filter(path => path !== null);
+        event.locals.db.logger.fatal({ valibotErrorPaths }, error.message);
+    } else if (error instanceof AssertionError) {
+        event.locals.db.logger.fatal({ nodeAssertionError: error }, error.message);
+    } else if (error instanceof Error) {
+        event.locals.db.logger.fatal({ error }, error.message);
+    } else {
+        event.locals.db.logger.fatal({ unknownError: error });
+    }
 }


### PR DESCRIPTION
This PR introduces improvements to the transparency of our logging and the traceability of our errors. 

Its main feature is to define the `handleError` hook, thus cleaning up how errors pop up in our logs. The code for this was lifted mostly intact from @BastiDood 's implementation in Spectro.

Aside from this, I've also returned the request `method` and `url` to being embedded as part of the child logger created in `handle`. This does increase the information density and redundancy on the logs so I do kinda expect this to be removed upon returning to production when we have the benefits of a log aggregator.