### PR TITLE
fix(lib/server/database): correct queries related to draft start

### DIFF
--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -487,7 +487,7 @@ export class Database implements Loggable {
           .where(
             or(
               gte(sql`coalesce(${draftedCte.draftees}, 0)`, schema.lab.quota),
-              eq(preferredCte.preferrers, 0),
+              eq(sql`coalesce(${preferredCte.preferrers}, 0)`, 0),
             ),
           )
 

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -436,7 +436,7 @@ export class Database implements Loggable {
         .with(draftsCte)
         .select({
           labId: schema.facultyChoiceUser.labId,
-          draftees: count(schema.facultyChoiceUser.studentUserId),
+          draftees: count(schema.facultyChoiceUser.studentUserId).as("draftees"),
         })
         .from(draftsCte)
         .innerJoin(
@@ -469,7 +469,7 @@ export class Database implements Loggable {
       this.#db
         .select({
           labId: preferredSubquery.labId,
-          preferrers: countDistinct(preferredSubquery.studentUserId),
+          preferrers: countDistinct(preferredSubquery.studentUserId).as("preferrers"),
         })
         .from(preferredSubquery)
         .groupBy(preferredSubquery.labId),


### PR DESCRIPTION
This PR corrects a query that operates during the actual draft start following the selection of student rankings.

- `autoAcknowledgeLabsWithoutPreferences`