### PR TITLE
fix: correct typos in dummy user action

### DIFF
--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -34,5 +34,6 @@ export const actions = {
           cookies.set('sid', dummySessionId, { path: '/', httpOnly: true, sameSite: 'lax' });
           redirect(307, '/');
         },
-    }: {}),
+      }
+    : {}),
 };


### PR DESCRIPTION
This PR corrects some bugs introduced in the dummy user creation action, namely:

+ Removing the session guard at the start of the dummy action
+ Reversing the order of the ternary statement that empties `dummy` out when `dev` is `false`
