### PR TITLE
Reinstate email notification system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,6 @@ on:
 
 jobs:
   build:
-    env:
-      POSTGRES_URL: 'postgres://example.com'
-      GOOGLE_OAUTH_CLIENT_ID: 'id.google.com'
-      GOOGLE_OAUTH_CLIENT_SECRET: 'secret.google.com'
-      GOOGLE_OAUTH_REDIRECT_URI: 'https://drap.dcs.upd.edu.ph/auth/callback'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     env_file:
       - .env
   redis:
-    image: redis:latest
+    image: redis:8.0.3-alpine
     profiles:
       - dev
       - prod

--- a/drizzle/0008_add-email-notification.sql
+++ b/drizzle/0008_add-email-notification.sql
@@ -1,6 +1,6 @@
 CREATE TABLE "email"."notification" (
 	"id" "ulid" PRIMARY KEY DEFAULT gen_ulid() NOT NULL,
-	"created_at" timestamp DEFAULT now() NOT NULL,
-	"delivered_at" timestamp,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"delivered_at" timestamp with time zone,
 	"metadata" jsonb NOT NULL
 );

--- a/drizzle/0008_add-email-notifications.sql
+++ b/drizzle/0008_add-email-notifications.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "email"."notification" (
+	"id" "ulid" PRIMARY KEY DEFAULT gen_ulid() NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"delivered_at" timestamp,
+	"metadata" jsonb NOT NULL
+);

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "bc99b34f-2be1-4e7b-a64e-1dde8bbd995d",
+  "id": "29d8c134-2867-4306-9bd0-e4649cd8d393",
   "prevId": "b4113983-fc3e-49a2-9c5c-990f893c6fdf",
   "version": "7",
   "dialect": "postgresql",
@@ -827,14 +827,14 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
         },
         "delivered_at": {
           "name": "delivered_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
         },

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,914 @@
+{
+  "id": "bc99b34f-2be1-4e7b-a64e-1dde8bbd995d",
+  "prevId": "b4113983-fc3e-49a2-9c5c-990f893c6fdf",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "drap.draft": {
+      "name": "draft",
+      "schema": "drap",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "draft_id_seq",
+            "schema": "drap",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "curr_round": {
+          "name": "curr_round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "max_rounds": {
+          "name": "max_rounds",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_period": {
+          "name": "active_period",
+          "type": "tstzrange",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "tstzrange(now(), null, '[)')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "draft_curr_round_within_bounds": {
+          "name": "draft_curr_round_within_bounds",
+          "value": "\"drap\".\"draft\".\"curr_round\" BETWEEN 0 AND \"drap\".\"draft\".\"max_rounds\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "drap.faculty_choice": {
+      "name": "faculty_choice",
+      "schema": "drap",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "faculty_choice_draft_id_draft_id_fk": {
+          "name": "faculty_choice_draft_id_draft_id_fk",
+          "tableFrom": "faculty_choice",
+          "tableTo": "draft",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "faculty_choice_lab_id_lab_lab_id_fk": {
+          "name": "faculty_choice_lab_id_lab_lab_id_fk",
+          "tableFrom": "faculty_choice",
+          "tableTo": "lab",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "lab_id"
+          ],
+          "columnsTo": [
+            "lab_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "faculty_choice_user_id_user_id_fk": {
+          "name": "faculty_choice_user_id_user_id_fk",
+          "tableFrom": "faculty_choice",
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "faculty_choice_only_once_per_draft_round": {
+          "name": "faculty_choice_only_once_per_draft_round",
+          "nullsNotDistinct": true,
+          "columns": [
+            "draft_id",
+            "round",
+            "lab_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "faculty_choice_post_registration_round_check": {
+          "name": "faculty_choice_post_registration_round_check",
+          "value": "\"drap\".\"faculty_choice\".\"round\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "drap.faculty_choice_user": {
+      "name": "faculty_choice_user",
+      "schema": "drap",
+      "columns": {
+        "faculty_user_id": {
+          "name": "faculty_user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_user_id": {
+          "name": "student_user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "faculty_choice_user_faculty_user_id_user_id_fk": {
+          "name": "faculty_choice_user_faculty_user_id_user_id_fk",
+          "tableFrom": "faculty_choice_user",
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "faculty_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "faculty_choice_user_student_user_id_user_id_fk": {
+          "name": "faculty_choice_user_student_user_id_user_id_fk",
+          "tableFrom": "faculty_choice_user",
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "student_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "faculty_choice_user_draft_id_draft_id_fk": {
+          "name": "faculty_choice_user_draft_id_draft_id_fk",
+          "tableFrom": "faculty_choice_user",
+          "tableTo": "draft",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "faculty_choice_user_lab_id_lab_lab_id_fk": {
+          "name": "faculty_choice_user_lab_id_lab_lab_id_fk",
+          "tableFrom": "faculty_choice_user",
+          "tableTo": "lab",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "lab_id"
+          ],
+          "columnsTo": [
+            "lab_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "faculty_choice_user_draft_id_round_lab_id_faculty_choice_draft_id_round_lab_id_fk": {
+          "name": "faculty_choice_user_draft_id_round_lab_id_faculty_choice_draft_id_round_lab_id_fk",
+          "tableFrom": "faculty_choice_user",
+          "tableTo": "faculty_choice",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "draft_id",
+            "round",
+            "lab_id"
+          ],
+          "columnsTo": [
+            "draft_id",
+            "round",
+            "lab_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "faculty_choice_user_unique_student_selection_per_draft": {
+          "name": "faculty_choice_user_unique_student_selection_per_draft",
+          "nullsNotDistinct": false,
+          "columns": [
+            "draft_id",
+            "student_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "faculty_choice_user_different_student_and_faculty_users": {
+          "name": "faculty_choice_user_different_student_and_faculty_users",
+          "value": "\"drap\".\"faculty_choice_user\".\"student_user_id\" <> \"drap\".\"faculty_choice_user\".\"faculty_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "drap.lab": {
+      "name": "lab",
+      "schema": "drap",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lab_name": {
+          "name": "lab_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quota": {
+          "name": "quota",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lab_lab_name_unique": {
+          "name": "lab_lab_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lab_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "lab_quota_non_negative_check": {
+          "name": "lab_quota_non_negative_check",
+          "value": "\"drap\".\"lab\".\"quota\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "drap.student_rank": {
+      "name": "student_rank",
+      "schema": "drap",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "student_rank_draft_id_draft_id_fk": {
+          "name": "student_rank_draft_id_draft_id_fk",
+          "tableFrom": "student_rank",
+          "tableTo": "draft",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "student_rank_user_id_user_id_fk": {
+          "name": "student_rank_user_id_user_id_fk",
+          "tableFrom": "student_rank",
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "student_rank_draft_id_user_id_pk": {
+          "name": "student_rank_draft_id_user_id_pk",
+          "columns": [
+            "draft_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "drap.student_rank_lab": {
+      "name": "student_rank_lab",
+      "schema": "drap",
+      "columns": {
+        "draft_id": {
+          "name": "draft_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remark": {
+          "name": "remark",
+          "type": "varchar(1028)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "student_rank_lab_draft_id_draft_id_fk": {
+          "name": "student_rank_lab_draft_id_draft_id_fk",
+          "tableFrom": "student_rank_lab",
+          "tableTo": "draft",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "student_rank_lab_user_id_user_id_fk": {
+          "name": "student_rank_lab_user_id_user_id_fk",
+          "tableFrom": "student_rank_lab",
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "student_rank_lab_lab_id_lab_lab_id_fk": {
+          "name": "student_rank_lab_lab_id_lab_lab_id_fk",
+          "tableFrom": "student_rank_lab",
+          "tableTo": "lab",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "lab_id"
+          ],
+          "columnsTo": [
+            "lab_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "student_rank_lab_draft_id_user_id_lab_id_pk": {
+          "name": "student_rank_lab_draft_id_user_id_lab_id_pk",
+          "columns": [
+            "draft_id",
+            "user_id",
+            "lab_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "drap.user": {
+      "name": "user",
+      "schema": "drap",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_ulid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "google_user_id": {
+          "name": "google_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "given_name": {
+          "name": "given_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "family_name": {
+          "name": "family_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_lab_id_lab_lab_id_fk": {
+          "name": "user_lab_id_lab_lab_id_fk",
+          "tableFrom": "user",
+          "tableTo": "lab",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "lab_id"
+          ],
+          "columnsTo": [
+            "lab_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_student_number_unique": {
+          "name": "user_student_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "student_number"
+          ]
+        },
+        "user_google_user_id_unique": {
+          "name": "user_google_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_user_id"
+          ]
+        },
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_student_number_within_bounds": {
+          "name": "user_student_number_within_bounds",
+          "value": "\"drap\".\"user\".\"student_number\" BETWEEN 100000000 AND 1000000000"
+        },
+        "user_email_non_empty": {
+          "name": "user_email_non_empty",
+          "value": "\"drap\".\"user\".\"email\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "auth.pending": {
+      "name": "pending",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_ulid()"
+        },
+        "expiration": {
+          "name": "expiration",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now() + INTERVAL '15 minutes'"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_bytes(64)"
+        },
+        "has_extended_scope": {
+          "name": "has_extended_scope",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.session": {
+      "name": "session",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_ulid()"
+        },
+        "expiration": {
+          "name": "expiration",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "email.candidate_sender": {
+      "name": "candidate_sender",
+      "schema": "email",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiration": {
+          "name": "expiration",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "candidate_sender_user_id_user_id_fk": {
+          "name": "candidate_sender_user_id_user_id_fk",
+          "tableFrom": "candidate_sender",
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "email.designated_sender": {
+      "name": "designated_sender",
+      "schema": "email",
+      "columns": {
+        "candidate_sender_user_id": {
+          "name": "candidate_sender_user_id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "designated_sender_candidate_sender_user_id_candidate_sender_user_id_fk": {
+          "name": "designated_sender_candidate_sender_user_id_candidate_sender_user_id_fk",
+          "tableFrom": "designated_sender",
+          "tableTo": "candidate_sender",
+          "schemaTo": "email",
+          "columnsFrom": [
+            "candidate_sender_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "email.notification": {
+      "name": "notification",
+      "schema": "email",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_ulid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "drap": "drap",
+    "auth": "auth",
+    "email": "email"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "drap.active_lab_view": {
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lab_name": {
+          "name": "lab_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quota": {
+          "name": "quota",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"created_at\", \"lab_id\", \"lab_name\", \"quota\", \"deleted_at\" from \"drap\".\"lab\" where \"drap\".\"lab\".\"deleted_at\" is null",
+      "name": "active_lab_view",
+      "schema": "drap",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1752132714164,
       "tag": "0007_reinstate-active-lab-view",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1752242248818,
+      "tag": "0008_add-email-notifications",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -61,8 +61,8 @@
     {
       "idx": 8,
       "version": "7",
-      "when": 1752242248818,
-      "tag": "0008_add-email-notifications",
+      "when": 1752326729076,
+      "tag": "0008_add-email-notification",
       "breakpoints": true
     }
   ]

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -47,7 +47,6 @@
     {
       "idx": 6,
       "version": "7",
-<<<<<<< HEAD
       "when": 1752132691196,
       "tag": "0006_use-timestamp-with-timezone",
       "breakpoints": true
@@ -57,10 +56,6 @@
       "version": "7",
       "when": 1752132714164,
       "tag": "0007_reinstate-active-lab-view",
-=======
-      "when": 1752118093300,
-      "tag": "0006_add-notifications-table",
->>>>>>> 070fbf0 (chore: generate migrations)
       "breakpoints": true
     }
   ]

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -78,7 +78,10 @@ export default defineConfig(
       '@typescript-eslint/no-import-type-side-effects': 'error',
       '@typescript-eslint/no-loop-func': 'error',
       '@typescript-eslint/no-unnecessary-parameter-property-assignment': 'error',
-      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { varsIgnorePattern: '^_', argsIgnorePattern: '^_' },
+      ],
       '@typescript-eslint/no-use-before-define': 'error',
       '@typescript-eslint/no-useless-empty-export': 'error',
       '@typescript-eslint/parameter-properties': ['error', { prefer: 'parameter-property' }],

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@eslint/css": "^0.9.0",
-    "@eslint/js": "^9.30.0",
+    "@eslint/js": "^9.30.1",
     "@html-eslint/eslint-plugin": "^0.42.0",
     "@html-eslint/parser": "^0.42.0",
     "@sveltejs/adapter-node": "^5.2.13",

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "valibot": "^1.1.0"
   },
   "devDependencies": {
-    "@eslint/css": "^0.10.0",
-    "@eslint/js": "^9.31.0",
+    "@eslint/css": "^0.9.0",
+    "@eslint/js": "^9.30.0",
     "@html-eslint/eslint-plugin": "^0.42.0",
     "@html-eslint/parser": "^0.42.0",
     "@sveltejs/adapter-node": "^5.2.13",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@steeze-ui/simple-icons": "^1.10.1",
     "@steeze-ui/svelte-icon": "~1.6.2",
     "@sveltejs/kit": "^2.22.5",
-    "bullmq": "^5.56.0",
+    "bullmq": "^5.56.3",
     "date-fns": "^4.1.0",
     "drizzle-orm": "^0.44.2",
     "itertools": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
-    "@skeletonlabs/skeleton": "^3.1.4",
-    "@skeletonlabs/skeleton-svelte": "^1.2.4",
+    "@skeletonlabs/skeleton": "^3.1.5",
+    "@skeletonlabs/skeleton-svelte": "^1.3.0",
     "@steeze-ui/heroicons": "^2.4.2",
     "@steeze-ui/simple-icons": "^1.10.1",
     "@steeze-ui/svelte-icon": "~1.6.2",
     "@sveltejs/kit": "^2.22.5",
-    "bullmq": "^5.56.3",
+    "bullmq": "^5.56.4",
     "date-fns": "^4.1.0",
     "drizzle-orm": "^0.44.2",
     "itertools": "^2.4.1",
@@ -38,8 +38,8 @@
     "valibot": "^1.1.0"
   },
   "devDependencies": {
-    "@eslint/css": "^0.9.0",
-    "@eslint/js": "^9.30.1",
+    "@eslint/css": "^0.10.0",
+    "@eslint/js": "^9.31.0",
     "@html-eslint/eslint-plugin": "^0.42.0",
     "@html-eslint/parser": "^0.42.0",
     "@sveltejs/adapter-node": "^5.2.13",
@@ -50,7 +50,7 @@
     "@types/node": "^24.0.13",
     "@types/pg": "^8.15.4",
     "drizzle-kit": "^0.31.4",
-    "eslint": "^9.30.1",
+    "eslint": "^9.31.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-svelte": "^3.10.1",
     "globals": "^16.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,10 +25,10 @@ importers:
         version: 1.6.2(svelte@5.35.6)
       '@sveltejs/kit':
         specifier: ^2.22.5
-        version: 2.22.5(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.6)(vite@7.0.4(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)))(svelte@5.35.6)(vite@7.0.4(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1))
+        version: 2.22.4(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.35.5)(vite@6.3.5(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)))(svelte@5.35.5)(vite@6.3.5(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1))
       bullmq:
-        specifier: ^5.56.0
-        version: 5.56.0
+        specifier: ^5.56.3
+        version: 5.56.3
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -1128,8 +1128,8 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
-  bullmq@5.56.0:
-    resolution: {integrity: sha512-j5ct2tdc9M8PKcjhJw+euO24BsO1wXBAkNGXYI1R1qvh7FvRldZ5wtLixLWqQ4/crafj0Vrwi+y1kXFXMwBJFA==}
+  bullmq@5.56.3:
+    resolution: {integrity: sha512-03szheVTKfLsCm5EwzOjSSUTI0UIGJjTUgX91W4+a0pj6SSfiuuNzB29QJh+T3bcgUZUHuTp01Jyxa101sv0Lg==}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -1701,8 +1701,8 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  luxon@3.6.1:
-    resolution: {integrity: sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==}
+  luxon@3.7.1:
+    resolution: {integrity: sha512-RkRWjA926cTvz5rAb1BqyWkKbbjzCGchDUIKMCUvNi17j6f6j8uHGDV82Aqcqtzd+icoYpELmG3ksgGiFNNcNg==}
     engines: {node: '>=12'}
 
   magic-string@0.30.17:
@@ -3287,7 +3287,7 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
-  bullmq@5.56.0:
+  bullmq@5.56.3:
     dependencies:
       cron-parser: 4.9.0
       ioredis: 5.6.1
@@ -3334,7 +3334,7 @@ snapshots:
 
   cron-parser@4.9.0:
     dependencies:
-      luxon: 3.6.1
+      luxon: 3.7.1
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3779,7 +3779,7 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  luxon@3.6.1: {}
+  luxon@3.7.1: {}
 
   magic-string@0.30.17:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@skeletonlabs/skeleton':
-        specifier: ^3.1.4
-        version: 3.1.4(tailwindcss@4.1.11)
+        specifier: ^3.1.5
+        version: 3.1.5(tailwindcss@4.1.11)
       '@skeletonlabs/skeleton-svelte':
-        specifier: ^1.2.4
-        version: 1.2.4(svelte@5.35.6)
+        specifier: ^1.3.0
+        version: 1.3.0(svelte@5.35.6)
       '@steeze-ui/heroicons':
         specifier: ^2.4.2
         version: 2.4.2
@@ -27,8 +27,8 @@ importers:
         specifier: ^2.22.5
         version: 2.22.5(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.6)(vite@7.0.4(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)))(svelte@5.35.6)(vite@7.0.4(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1))
       bullmq:
-        specifier: ^5.56.3
-        version: 5.56.3
+        specifier: ^5.56.4
+        version: 5.56.4
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -61,14 +61,14 @@ importers:
         version: 1.1.0(typescript@5.8.3)
     devDependencies:
       '@eslint/css':
-        specifier: ^0.9.0
-        version: 0.9.0
+        specifier: ^0.10.0
+        version: 0.10.0
       '@eslint/js':
-        specifier: ^9.30.1
-        version: 9.30.1
+        specifier: ^9.31.0
+        version: 9.31.0
       '@html-eslint/eslint-plugin':
         specifier: ^0.42.0
-        version: 0.42.0(eslint@9.30.1(jiti@2.4.2))
+        version: 0.42.0(eslint@9.31.0(jiti@2.4.2))
       '@html-eslint/parser':
         specifier: ^0.42.0
         version: 0.42.0
@@ -97,14 +97,14 @@ importers:
         specifier: ^0.31.4
         version: 0.31.4
       eslint:
-        specifier: ^9.30.1
-        version: 9.30.1(jiti@2.4.2)
+        specifier: ^9.31.0
+        version: 9.31.0(jiti@2.4.2)
       eslint-config-prettier:
         specifier: ^10.1.5
-        version: 10.1.5(eslint@9.30.1(jiti@2.4.2))
+        version: 10.1.5(eslint@9.31.0(jiti@2.4.2))
       eslint-plugin-svelte:
         specifier: ^3.10.1
-        version: 3.10.1(eslint@9.30.1(jiti@2.4.2))(svelte@5.35.6)
+        version: 3.10.1(eslint@9.31.0(jiti@2.4.2))(svelte@5.35.6)
       globals:
         specifier: ^16.3.0
         version: 16.3.0
@@ -128,7 +128,7 @@ importers:
         version: 4.1.11
       typescript-eslint:
         specifier: ^8.36.0
-        version: 8.36.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
+        version: 8.36.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
       vite:
         specifier: ^7.0.4
         version: 7.0.4(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)
@@ -476,16 +476,16 @@ packages:
     resolution: {integrity: sha512-5DIsBME23tUQD5zHD+T38lC2DG4jB8x8JRa+yDncLne2TIZA0VuCpcSazOX1EC+sM/q8w24qeevXfmfsIxAeqA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
-  '@eslint/css@0.9.0':
-    resolution: {integrity: sha512-fq8hYnjipdzVDSU/bXqv7qlvdjDA27Nq7DhQXzlPElLlVon3lnKovIM/6HaUrq1bz7EPgRobr+vOhpeM6z0X4w==}
+  '@eslint/css@0.10.0':
+    resolution: {integrity: sha512-pHoYRWS08oeU0qVez1pZCcbqHzoJnM5VMtrxH2nWDJ0ukq9DkwWV1BTY+PWK+eWBbndN9W0O9WjJTyAHsDoPOg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/eslintrc@3.3.1':
     resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/js@9.30.1':
-    resolution: {integrity: sha512-zXhuECFlyep42KZUhWjfvsmXGX39W8K8LFb8AWXM9gSV9dQB+MrJGLKvW6Zw0Ggnbpw0VHTtrhFXYe3Gym18jg==}
+  '@eslint/js@9.31.0':
+    resolution: {integrity: sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/object-schema@2.1.6':
@@ -641,113 +641,113 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.44.2':
-    resolution: {integrity: sha512-g0dF8P1e2QYPOj1gu7s/3LVP6kze9A7m6x0BZ9iTdXK8N5c2V7cpBKHV3/9A4Zd8xxavdhK0t4PnqjkqVmUc9Q==}
+  '@rollup/rollup-android-arm-eabi@4.45.0':
+    resolution: {integrity: sha512-2o/FgACbji4tW1dzXOqAV15Eu7DdgbKsF2QKcxfG4xbh5iwU7yr5RRP5/U+0asQliSYv5M4o7BevlGIoSL0LXg==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.44.2':
-    resolution: {integrity: sha512-Yt5MKrOosSbSaAK5Y4J+vSiID57sOvpBNBR6K7xAaQvk3MkcNVV0f9fE20T+41WYN8hDn6SGFlFrKudtx4EoxA==}
+  '@rollup/rollup-android-arm64@4.45.0':
+    resolution: {integrity: sha512-PSZ0SvMOjEAxwZeTx32eI/j5xSYtDCRxGu5k9zvzoY77xUNssZM+WV6HYBLROpY5CkXsbQjvz40fBb7WPwDqtQ==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.44.2':
-    resolution: {integrity: sha512-EsnFot9ZieM35YNA26nhbLTJBHD0jTwWpPwmRVDzjylQT6gkar+zenfb8mHxWpRrbn+WytRRjE0WKsfaxBkVUA==}
+  '@rollup/rollup-darwin-arm64@4.45.0':
+    resolution: {integrity: sha512-BA4yPIPssPB2aRAWzmqzQ3y2/KotkLyZukVB7j3psK/U3nVJdceo6qr9pLM2xN6iRP/wKfxEbOb1yrlZH6sYZg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.44.2':
-    resolution: {integrity: sha512-dv/t1t1RkCvJdWWxQ2lWOO+b7cMsVw5YFaS04oHpZRWehI1h0fV1gF4wgGCTyQHHjJDfbNpwOi6PXEafRBBezw==}
+  '@rollup/rollup-darwin-x64@4.45.0':
+    resolution: {integrity: sha512-Pr2o0lvTwsiG4HCr43Zy9xXrHspyMvsvEw4FwKYqhli4FuLE5FjcZzuQ4cfPe0iUFCvSQG6lACI0xj74FDZKRA==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.44.2':
-    resolution: {integrity: sha512-W4tt4BLorKND4qeHElxDoim0+BsprFTwb+vriVQnFFtT/P6v/xO5I99xvYnVzKWrK6j7Hb0yp3x7V5LUbaeOMg==}
+  '@rollup/rollup-freebsd-arm64@4.45.0':
+    resolution: {integrity: sha512-lYE8LkE5h4a/+6VnnLiL14zWMPnx6wNbDG23GcYFpRW1V9hYWHAw9lBZ6ZUIrOaoK7NliF1sdwYGiVmziUF4vA==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.44.2':
-    resolution: {integrity: sha512-tdT1PHopokkuBVyHjvYehnIe20fxibxFCEhQP/96MDSOcyjM/shlTkZZLOufV3qO6/FQOSiJTBebhVc12JyPTA==}
+  '@rollup/rollup-freebsd-x64@4.45.0':
+    resolution: {integrity: sha512-PVQWZK9sbzpvqC9Q0GlehNNSVHR+4m7+wET+7FgSnKG3ci5nAMgGmr9mGBXzAuE5SvguCKJ6mHL6vq1JaJ/gvw==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.44.2':
-    resolution: {integrity: sha512-+xmiDGGaSfIIOXMzkhJ++Oa0Gwvl9oXUeIiwarsdRXSe27HUIvjbSIpPxvnNsRebsNdUo7uAiQVgBD1hVriwSQ==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.45.0':
+    resolution: {integrity: sha512-hLrmRl53prCcD+YXTfNvXd776HTxNh8wPAMllusQ+amcQmtgo3V5i/nkhPN6FakW+QVLoUUr2AsbtIRPFU3xIA==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.44.2':
-    resolution: {integrity: sha512-bDHvhzOfORk3wt8yxIra8N4k/N0MnKInCW5OGZaeDYa/hMrdPaJzo7CSkjKZqX4JFUWjUGm88lI6QJLCM7lDrA==}
+  '@rollup/rollup-linux-arm-musleabihf@4.45.0':
+    resolution: {integrity: sha512-XBKGSYcrkdiRRjl+8XvrUR3AosXU0NvF7VuqMsm7s5nRy+nt58ZMB19Jdp1RdqewLcaYnpk8zeVs/4MlLZEJxw==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.44.2':
-    resolution: {integrity: sha512-NMsDEsDiYghTbeZWEGnNi4F0hSbGnsuOG+VnNvxkKg0IGDvFh7UVpM/14mnMwxRxUf9AdAVJgHPvKXf6FpMB7A==}
+  '@rollup/rollup-linux-arm64-gnu@4.45.0':
+    resolution: {integrity: sha512-fRvZZPUiBz7NztBE/2QnCS5AtqLVhXmUOPj9IHlfGEXkapgImf4W9+FSkL8cWqoAjozyUzqFmSc4zh2ooaeF6g==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.44.2':
-    resolution: {integrity: sha512-lb5bxXnxXglVq+7imxykIp5xMq+idehfl+wOgiiix0191av84OqbjUED+PRC5OA8eFJYj5xAGcpAZ0pF2MnW+A==}
+  '@rollup/rollup-linux-arm64-musl@4.45.0':
+    resolution: {integrity: sha512-Btv2WRZOcUGi8XU80XwIvzTg4U6+l6D0V6sZTrZx214nrwxw5nAi8hysaXj/mctyClWgesyuxbeLylCBNauimg==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.44.2':
-    resolution: {integrity: sha512-Yl5Rdpf9pIc4GW1PmkUGHdMtbx0fBLE1//SxDmuf3X0dUC57+zMepow2LK0V21661cjXdTn8hO2tXDdAWAqE5g==}
+  '@rollup/rollup-linux-loongarch64-gnu@4.45.0':
+    resolution: {integrity: sha512-Li0emNnwtUZdLwHjQPBxn4VWztcrw/h7mgLyHiEI5Z0MhpeFGlzaiBHpSNVOMB/xucjXTTcO+dhv469Djr16KA==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.44.2':
-    resolution: {integrity: sha512-03vUDH+w55s680YYryyr78jsO1RWU9ocRMaeV2vMniJJW/6HhoTBwyyiiTPVHNWLnhsnwcQ0oH3S9JSBEKuyqw==}
+  '@rollup/rollup-linux-powerpc64le-gnu@4.45.0':
+    resolution: {integrity: sha512-sB8+pfkYx2kvpDCfd63d5ScYT0Fz1LO6jIb2zLZvmK9ob2D8DeVqrmBDE0iDK8KlBVmsTNzrjr3G1xV4eUZhSw==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.44.2':
-    resolution: {integrity: sha512-iYtAqBg5eEMG4dEfVlkqo05xMOk6y/JXIToRca2bAWuqjrJYJlx/I7+Z+4hSrsWU8GdJDFPL4ktV3dy4yBSrzg==}
+  '@rollup/rollup-linux-riscv64-gnu@4.45.0':
+    resolution: {integrity: sha512-5GQ6PFhh7E6jQm70p1aW05G2cap5zMOvO0se5JMecHeAdj5ZhWEHbJ4hiKpfi1nnnEdTauDXxPgXae/mqjow9w==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.44.2':
-    resolution: {integrity: sha512-e6vEbgaaqz2yEHqtkPXa28fFuBGmUJ0N2dOJK8YUfijejInt9gfCSA7YDdJ4nYlv67JfP3+PSWFX4IVw/xRIPg==}
+  '@rollup/rollup-linux-riscv64-musl@4.45.0':
+    resolution: {integrity: sha512-N/euLsBd1rekWcuduakTo/dJw6U6sBP3eUq+RXM9RNfPuWTvG2w/WObDkIvJ2KChy6oxZmOSC08Ak2OJA0UiAA==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.44.2':
-    resolution: {integrity: sha512-evFOtkmVdY3udE+0QKrV5wBx7bKI0iHz5yEVx5WqDJkxp9YQefy4Mpx3RajIVcM6o7jxTvVd/qpC1IXUhGc1Mw==}
+  '@rollup/rollup-linux-s390x-gnu@4.45.0':
+    resolution: {integrity: sha512-2l9sA7d7QdikL0xQwNMO3xURBUNEWyHVHfAsHsUdq+E/pgLTUcCE+gih5PCdmyHmfTDeXUWVhqL0WZzg0nua3g==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.44.2':
-    resolution: {integrity: sha512-/bXb0bEsWMyEkIsUL2Yt5nFB5naLAwyOWMEviQfQY1x3l5WsLKgvZf66TM7UTfED6erckUVUJQ/jJ1FSpm3pRQ==}
+  '@rollup/rollup-linux-x64-gnu@4.45.0':
+    resolution: {integrity: sha512-XZdD3fEEQcwG2KrJDdEQu7NrHonPxxaV0/w2HpvINBdcqebz1aL+0vM2WFJq4DeiAVT6F5SUQas65HY5JDqoPw==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.44.2':
-    resolution: {integrity: sha512-3D3OB1vSSBXmkGEZR27uiMRNiwN08/RVAcBKwhUYPaiZ8bcvdeEwWPvbnXvvXHY+A/7xluzcN+kaiOFNiOZwWg==}
+  '@rollup/rollup-linux-x64-musl@4.45.0':
+    resolution: {integrity: sha512-7ayfgvtmmWgKWBkCGg5+xTQ0r5V1owVm67zTrsEY1008L5ro7mCyGYORomARt/OquB9KY7LpxVBZes+oSniAAQ==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.44.2':
-    resolution: {integrity: sha512-VfU0fsMK+rwdK8mwODqYeM2hDrF2WiHaSmCBrS7gColkQft95/8tphyzv2EupVxn3iE0FI78wzffoULH1G+dkw==}
+  '@rollup/rollup-win32-arm64-msvc@4.45.0':
+    resolution: {integrity: sha512-B+IJgcBnE2bm93jEW5kHisqvPITs4ddLOROAcOc/diBgrEiQJJ6Qcjby75rFSmH5eMGrqJryUgJDhrfj942apQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.44.2':
-    resolution: {integrity: sha512-+qMUrkbUurpE6DVRjiJCNGZBGo9xM4Y0FXU5cjgudWqIBWbcLkjE3XprJUsOFgC6xjBClwVa9k6O3A7K3vxb5Q==}
+  '@rollup/rollup-win32-ia32-msvc@4.45.0':
+    resolution: {integrity: sha512-+CXwwG66g0/FpWOnP/v1HnrGVSOygK/osUbu3wPRy8ECXjoYKjRAyfxYpDQOfghC5qPJYLPH0oN4MCOjwgdMug==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.44.2':
-    resolution: {integrity: sha512-3+QZROYfJ25PDcxFF66UEk8jGWigHJeecZILvkPkyQN7oc5BvFo4YEXFkOs154j3FTMp9mn9Ky8RCOwastduEA==}
+  '@rollup/rollup-win32-x64-msvc@4.45.0':
+    resolution: {integrity: sha512-SRf1cytG7wqcHVLrBc9VtPK4pU5wxiB/lNIkNmW2ApKXIg+RpqwHfsaEK+e7eH4A1BpI6BX/aBWXxZCIrJg3uA==}
     cpu: [x64]
     os: [win32]
 
-  '@skeletonlabs/skeleton-svelte@1.2.4':
-    resolution: {integrity: sha512-0rQ/7Dx8dqdBNJ6/qQa69iMYwMdRG4RJTg35CwPU6CsKE6Ee9fWNd+bWriLFsyYaOTNNTgP8UeXlWaTowr0OSg==}
+  '@skeletonlabs/skeleton-svelte@1.3.0':
+    resolution: {integrity: sha512-hXnwCF6OEuZ43m6J1HTT88ui2KJyPI7NxWRbh+9lDudzHIjYqkgz0gtHq8xvGn51X3wMRq4KQEWnsLhHGRr3Fw==}
     peerDependencies:
       svelte: ^5.20.0
 
-  '@skeletonlabs/skeleton@3.1.4':
-    resolution: {integrity: sha512-sp7+FZN9bYR4ULtVop39bZ7a7l9tbu/VCwlgJxh2YQ9hrx85Rh0If+VYajPL18eD4CsnIOmsltEspBuRSjQYVw==}
+  '@skeletonlabs/skeleton@3.1.5':
+    resolution: {integrity: sha512-KonACeom+WCiV9ZRLOOQRpzSlvdfZbrMHM/5W/BjvbBHx8el1hv55Ba6t8ii4g8qIjaENdypkFncrOFsfPpeJQ==}
     peerDependencies:
       tailwindcss: ^4.0.0
 
@@ -1128,8 +1128,8 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
-  bullmq@5.56.3:
-    resolution: {integrity: sha512-03szheVTKfLsCm5EwzOjSSUTI0UIGJjTUgX91W4+a0pj6SSfiuuNzB29QJh+T3bcgUZUHuTp01Jyxa101sv0Lg==}
+  bullmq@5.56.4:
+    resolution: {integrity: sha512-5wSHd0oXs2jS6P+6tay/01Iz0cWRK8iYcscKtpS/GewEq0bJZwbkMZc77GJVOT9SP+UQuXA2y+pQTdCQJel7kQ==}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -1380,8 +1380,8 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  eslint@9.30.1:
-    resolution: {integrity: sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==}
+  eslint@9.31.0:
+    resolution: {integrity: sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
@@ -2062,8 +2062,8 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rollup@4.44.2:
-    resolution: {integrity: sha512-PVoapzTwSEcelaWGth3uR66u7ZRo6qhPHc0f2uRO9fX6XDVNrIiGYS0Pj9+R8yIIYSD/mCx2b16Ws9itljKSPg==}
+  rollup@4.45.0:
+    resolution: {integrity: sha512-WLjEcJRIo7i3WDDgOIJqVI2d+lAC3EwvOGy+Xfq6hs+GQuAA4Di/H72xmXkOhrIWFg2PFYSKZYfH0f4vfKXN4A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -2475,9 +2475,9 @@ snapshots:
   '@esbuild/win32-x64@0.25.6':
     optional: true
 
-  '@eslint-community/eslint-utils@4.7.0(eslint@9.30.1(jiti@2.4.2))':
+  '@eslint-community/eslint-utils@4.7.0(eslint@9.31.0(jiti@2.4.2))':
     dependencies:
-      eslint: 9.30.1(jiti@2.4.2)
+      eslint: 9.31.0(jiti@2.4.2)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
@@ -2505,7 +2505,7 @@ snapshots:
       mdn-data: 2.21.0
       source-map-js: 1.2.1
 
-  '@eslint/css@0.9.0':
+  '@eslint/css@0.10.0':
     dependencies:
       '@eslint/core': 0.14.0
       '@eslint/css-tree': 3.6.1
@@ -2525,7 +2525,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@9.30.1': {}
+  '@eslint/js@9.31.0': {}
 
   '@eslint/object-schema@2.1.6': {}
 
@@ -2545,13 +2545,13 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
-  '@html-eslint/eslint-plugin@0.42.0(eslint@9.30.1(jiti@2.4.2))':
+  '@html-eslint/eslint-plugin@0.42.0(eslint@9.31.0(jiti@2.4.2))':
     dependencies:
       '@eslint/plugin-kit': 0.3.3
       '@html-eslint/parser': 0.42.0
       '@html-eslint/template-parser': 0.42.0
       '@html-eslint/template-syntax-parser': 0.42.0
-      eslint: 9.30.1(jiti@2.4.2)
+      eslint: 9.31.0(jiti@2.4.2)
 
   '@html-eslint/parser@0.42.0':
     dependencies:
@@ -2629,9 +2629,9 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@rollup/plugin-commonjs@28.0.6(rollup@4.44.2)':
+  '@rollup/plugin-commonjs@28.0.6(rollup@4.45.0)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.44.2)
+      '@rollup/pluginutils': 5.2.0(rollup@4.45.0)
       commondir: 1.0.1
       estree-walker: 2.0.2
       fdir: 6.4.6(picomatch@4.0.2)
@@ -2639,93 +2639,93 @@ snapshots:
       magic-string: 0.30.17
       picomatch: 4.0.2
     optionalDependencies:
-      rollup: 4.44.2
+      rollup: 4.45.0
 
-  '@rollup/plugin-json@6.1.0(rollup@4.44.2)':
+  '@rollup/plugin-json@6.1.0(rollup@4.45.0)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.44.2)
+      '@rollup/pluginutils': 5.2.0(rollup@4.45.0)
     optionalDependencies:
-      rollup: 4.44.2
+      rollup: 4.45.0
 
-  '@rollup/plugin-node-resolve@16.0.1(rollup@4.44.2)':
+  '@rollup/plugin-node-resolve@16.0.1(rollup@4.45.0)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.44.2)
+      '@rollup/pluginutils': 5.2.0(rollup@4.45.0)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.10
     optionalDependencies:
-      rollup: 4.44.2
+      rollup: 4.45.0
 
-  '@rollup/pluginutils@5.2.0(rollup@4.44.2)':
+  '@rollup/pluginutils@5.2.0(rollup@4.45.0)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.2
     optionalDependencies:
-      rollup: 4.44.2
+      rollup: 4.45.0
 
-  '@rollup/rollup-android-arm-eabi@4.44.2':
+  '@rollup/rollup-android-arm-eabi@4.45.0':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.44.2':
+  '@rollup/rollup-android-arm64@4.45.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.44.2':
+  '@rollup/rollup-darwin-arm64@4.45.0':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.44.2':
+  '@rollup/rollup-darwin-x64@4.45.0':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.44.2':
+  '@rollup/rollup-freebsd-arm64@4.45.0':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.44.2':
+  '@rollup/rollup-freebsd-x64@4.45.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.44.2':
+  '@rollup/rollup-linux-arm-gnueabihf@4.45.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.44.2':
+  '@rollup/rollup-linux-arm-musleabihf@4.45.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.44.2':
+  '@rollup/rollup-linux-arm64-gnu@4.45.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.44.2':
+  '@rollup/rollup-linux-arm64-musl@4.45.0':
     optional: true
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.44.2':
+  '@rollup/rollup-linux-loongarch64-gnu@4.45.0':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.44.2':
+  '@rollup/rollup-linux-powerpc64le-gnu@4.45.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.44.2':
+  '@rollup/rollup-linux-riscv64-gnu@4.45.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.44.2':
+  '@rollup/rollup-linux-riscv64-musl@4.45.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.44.2':
+  '@rollup/rollup-linux-s390x-gnu@4.45.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.44.2':
+  '@rollup/rollup-linux-x64-gnu@4.45.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.44.2':
+  '@rollup/rollup-linux-x64-musl@4.45.0':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.44.2':
+  '@rollup/rollup-win32-arm64-msvc@4.45.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.44.2':
+  '@rollup/rollup-win32-ia32-msvc@4.45.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.44.2':
+  '@rollup/rollup-win32-x64-msvc@4.45.0':
     optional: true
 
-  '@skeletonlabs/skeleton-svelte@1.2.4(svelte@5.35.6)':
+  '@skeletonlabs/skeleton-svelte@1.3.0(svelte@5.35.6)':
     dependencies:
       '@zag-js/accordion': 1.18.3
       '@zag-js/avatar': 1.18.3
@@ -2746,7 +2746,7 @@ snapshots:
       '@zag-js/tooltip': 1.18.3
       svelte: 5.35.6
 
-  '@skeletonlabs/skeleton@3.1.4(tailwindcss@4.1.11)':
+  '@skeletonlabs/skeleton@3.1.5(tailwindcss@4.1.11)':
     dependencies:
       tailwindcss: 4.1.11
 
@@ -2764,11 +2764,11 @@ snapshots:
 
   '@sveltejs/adapter-node@5.2.13(@sveltejs/kit@2.22.5(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.6)(vite@7.0.4(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)))(svelte@5.35.6)(vite@7.0.4(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)))':
     dependencies:
-      '@rollup/plugin-commonjs': 28.0.6(rollup@4.44.2)
-      '@rollup/plugin-json': 6.1.0(rollup@4.44.2)
-      '@rollup/plugin-node-resolve': 16.0.1(rollup@4.44.2)
+      '@rollup/plugin-commonjs': 28.0.6(rollup@4.45.0)
+      '@rollup/plugin-json': 6.1.0(rollup@4.45.0)
+      '@rollup/plugin-node-resolve': 16.0.1(rollup@4.45.0)
       '@sveltejs/kit': 2.22.5(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.6)(vite@7.0.4(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)))(svelte@5.35.6)(vite@7.0.4(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1))
-      rollup: 4.44.2
+      rollup: 4.45.0
 
   '@sveltejs/kit@2.22.5(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.6)(vite@7.0.4(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)))(svelte@5.35.6)(vite@7.0.4(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1))':
     dependencies:
@@ -2912,15 +2912,15 @@ snapshots:
 
   '@types/resolve@1.20.2': {}
 
-  '@typescript-eslint/eslint-plugin@8.36.0(@typescript-eslint/parser@8.36.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.36.0(@typescript-eslint/parser@8.36.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.36.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.36.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.36.0
-      '@typescript-eslint/type-utils': 8.36.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.36.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 8.36.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.36.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.36.0
-      eslint: 9.30.1(jiti@2.4.2)
+      eslint: 9.31.0(jiti@2.4.2)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -2929,14 +2929,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.36.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.36.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.36.0
       '@typescript-eslint/types': 8.36.0
       '@typescript-eslint/typescript-estree': 8.36.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.36.0
       debug: 4.4.1
-      eslint: 9.30.1(jiti@2.4.2)
+      eslint: 9.31.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -2959,12 +2959,12 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  '@typescript-eslint/type-utils@8.36.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.36.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.36.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.36.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.36.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
       debug: 4.4.1
-      eslint: 9.30.1(jiti@2.4.2)
+      eslint: 9.31.0(jiti@2.4.2)
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -2988,13 +2988,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.36.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)':
+  '@typescript-eslint/utils@8.36.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.30.1(jiti@2.4.2))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.31.0(jiti@2.4.2))
       '@typescript-eslint/scope-manager': 8.36.0
       '@typescript-eslint/types': 8.36.0
       '@typescript-eslint/typescript-estree': 8.36.0(typescript@5.8.3)
-      eslint: 9.30.1(jiti@2.4.2)
+      eslint: 9.31.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -3275,7 +3275,7 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
-  bullmq@5.56.3:
+  bullmq@5.56.4:
     dependencies:
       cron-parser: 4.9.0
       ioredis: 5.6.1
@@ -3440,15 +3440,15 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.5(eslint@9.30.1(jiti@2.4.2)):
+  eslint-config-prettier@10.1.5(eslint@9.31.0(jiti@2.4.2)):
     dependencies:
-      eslint: 9.30.1(jiti@2.4.2)
+      eslint: 9.31.0(jiti@2.4.2)
 
-  eslint-plugin-svelte@3.10.1(eslint@9.30.1(jiti@2.4.2))(svelte@5.35.6):
+  eslint-plugin-svelte@3.10.1(eslint@9.31.0(jiti@2.4.2))(svelte@5.35.6):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.30.1(jiti@2.4.2))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.31.0(jiti@2.4.2))
       '@jridgewell/sourcemap-codec': 1.5.4
-      eslint: 9.30.1(jiti@2.4.2)
+      eslint: 9.31.0(jiti@2.4.2)
       esutils: 2.0.3
       globals: 16.3.0
       known-css-properties: 0.37.0
@@ -3471,15 +3471,15 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.30.1(jiti@2.4.2):
+  eslint@9.31.0(jiti@2.4.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.30.1(jiti@2.4.2))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.31.0(jiti@2.4.2))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.21.0
       '@eslint/config-helpers': 0.3.0
-      '@eslint/core': 0.14.0
+      '@eslint/core': 0.15.1
       '@eslint/eslintrc': 3.3.1
-      '@eslint/js': 9.30.1
+      '@eslint/js': 9.31.0
       '@eslint/plugin-kit': 0.3.3
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
@@ -4051,30 +4051,30 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rollup@4.44.2:
+  rollup@4.45.0:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.44.2
-      '@rollup/rollup-android-arm64': 4.44.2
-      '@rollup/rollup-darwin-arm64': 4.44.2
-      '@rollup/rollup-darwin-x64': 4.44.2
-      '@rollup/rollup-freebsd-arm64': 4.44.2
-      '@rollup/rollup-freebsd-x64': 4.44.2
-      '@rollup/rollup-linux-arm-gnueabihf': 4.44.2
-      '@rollup/rollup-linux-arm-musleabihf': 4.44.2
-      '@rollup/rollup-linux-arm64-gnu': 4.44.2
-      '@rollup/rollup-linux-arm64-musl': 4.44.2
-      '@rollup/rollup-linux-loongarch64-gnu': 4.44.2
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.44.2
-      '@rollup/rollup-linux-riscv64-gnu': 4.44.2
-      '@rollup/rollup-linux-riscv64-musl': 4.44.2
-      '@rollup/rollup-linux-s390x-gnu': 4.44.2
-      '@rollup/rollup-linux-x64-gnu': 4.44.2
-      '@rollup/rollup-linux-x64-musl': 4.44.2
-      '@rollup/rollup-win32-arm64-msvc': 4.44.2
-      '@rollup/rollup-win32-ia32-msvc': 4.44.2
-      '@rollup/rollup-win32-x64-msvc': 4.44.2
+      '@rollup/rollup-android-arm-eabi': 4.45.0
+      '@rollup/rollup-android-arm64': 4.45.0
+      '@rollup/rollup-darwin-arm64': 4.45.0
+      '@rollup/rollup-darwin-x64': 4.45.0
+      '@rollup/rollup-freebsd-arm64': 4.45.0
+      '@rollup/rollup-freebsd-x64': 4.45.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.45.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.45.0
+      '@rollup/rollup-linux-arm64-gnu': 4.45.0
+      '@rollup/rollup-linux-arm64-musl': 4.45.0
+      '@rollup/rollup-linux-loongarch64-gnu': 4.45.0
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.45.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.45.0
+      '@rollup/rollup-linux-riscv64-musl': 4.45.0
+      '@rollup/rollup-linux-s390x-gnu': 4.45.0
+      '@rollup/rollup-linux-x64-gnu': 4.45.0
+      '@rollup/rollup-linux-x64-musl': 4.45.0
+      '@rollup/rollup-win32-arm64-msvc': 4.45.0
+      '@rollup/rollup-win32-ia32-msvc': 4.45.0
+      '@rollup/rollup-win32-x64-msvc': 4.45.0
       fsevents: 2.3.3
 
   run-parallel@1.2.0:
@@ -4208,12 +4208,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.36.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3):
+  typescript-eslint@8.36.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.36.0(@typescript-eslint/parser@8.36.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.36.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.36.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
-      eslint: 9.30.1(jiti@2.4.2)
+      '@typescript-eslint/eslint-plugin': 8.36.0(@typescript-eslint/parser@8.36.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.36.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.36.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
+      eslint: 9.31.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -4240,7 +4240,7 @@ snapshots:
       fdir: 6.4.6(picomatch@4.0.2)
       picomatch: 4.0.2
       postcss: 8.5.6
-      rollup: 4.44.2
+      rollup: 4.45.0
       tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 24.0.13

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,10 +61,10 @@ importers:
         version: 1.1.0(typescript@5.8.3)
     devDependencies:
       '@eslint/css':
-        specifier: ^0.10.0
-        version: 0.10.0
+        specifier: ^0.9.0
+        version: 0.9.0
       '@eslint/js':
-        specifier: ^9.31.0
+        specifier: ^9.30.0
         version: 9.31.0
       '@html-eslint/eslint-plugin':
         specifier: ^0.42.0
@@ -476,8 +476,8 @@ packages:
     resolution: {integrity: sha512-5DIsBME23tUQD5zHD+T38lC2DG4jB8x8JRa+yDncLne2TIZA0VuCpcSazOX1EC+sM/q8w24qeevXfmfsIxAeqA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
-  '@eslint/css@0.10.0':
-    resolution: {integrity: sha512-pHoYRWS08oeU0qVez1pZCcbqHzoJnM5VMtrxH2nWDJ0ukq9DkwWV1BTY+PWK+eWBbndN9W0O9WjJTyAHsDoPOg==}
+  '@eslint/css@0.9.0':
+    resolution: {integrity: sha512-fq8hYnjipdzVDSU/bXqv7qlvdjDA27Nq7DhQXzlPElLlVon3lnKovIM/6HaUrq1bz7EPgRobr+vOhpeM6z0X4w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/eslintrc@3.3.1':
@@ -2505,7 +2505,7 @@ snapshots:
       mdn-data: 2.21.0
       source-map-js: 1.2.1
 
-  '@eslint/css@0.10.0':
+  '@eslint/css@0.9.0':
     dependencies:
       '@eslint/core': 0.14.0
       '@eslint/css-tree': 3.6.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 1.6.2(svelte@5.35.6)
       '@sveltejs/kit':
         specifier: ^2.22.5
-        version: 2.22.4(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.35.5)(vite@6.3.5(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)))(svelte@5.35.5)(vite@6.3.5(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1))
+        version: 2.22.5(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.6)(vite@7.0.4(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)))(svelte@5.35.6)(vite@7.0.4(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1))
       bullmq:
         specifier: ^5.56.3
         version: 5.56.3
@@ -2206,20 +2206,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-<<<<<<< HEAD
-<<<<<<< HEAD
   undici-types@7.8.0:
     resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
-=======
-  ulid@3.0.1:
-    resolution: {integrity: sha512-dPJyqPzx8preQhqq24bBG1YNkvigm87K8kVEHCD+ruZg24t6IFEFv00xMWfxcC4djmFtiTLdFuADn4+DOz6R7Q==}
-    hasBin: true
-
-=======
->>>>>>> 9d95a47 (fix: remove unused dependency ulid)
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
->>>>>>> 6e5657a (feat: add ulid as dependency)
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -4232,16 +4220,7 @@ snapshots:
 
   typescript@5.8.3: {}
 
-<<<<<<< HEAD
-<<<<<<< HEAD
   undici-types@7.8.0: {}
-=======
-  ulid@3.0.1: {}
-
-=======
->>>>>>> 9d95a47 (fix: remove unused dependency ulid)
-  undici-types@6.21.0: {}
->>>>>>> 6e5657a (feat: add ulid as dependency)
 
   uri-js@4.4.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         specifier: ^0.9.0
         version: 0.9.0
       '@eslint/js':
-        specifier: ^9.30.0
+        specifier: ^9.30.1
         version: 9.31.0
       '@html-eslint/eslint-plugin':
         specifier: ^0.42.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ onlyBuiltDependencies:
   - '@tailwindcss/oxide'
   - core-js-pure
   - esbuild
+  - msgpackr-extract

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -25,14 +25,14 @@ const logger = pino(stream);
 // This is the global email queue manager
 const notificationDispatcher = new NotificationDispatcher(
   logger.child({ notifications: 'dispatch' }),
-  Database.withDefault(logger.child({ notifications: 'db' })),
+  Database.withLogger(logger.child({ notifications: 'db' })),
 );
 
 // This is the global email worker 
 const _ = new Worker(
   queueName,
   initializeProcessor(
-    Database.withDefault(logger.child({ notifications: 'db' })), 
+    Database.withLogger(logger.child({ notifications: 'db' })), 
     logger.child({ notifications: 'processor' })
   ),
   {
@@ -54,7 +54,7 @@ export async function handle({ event, resolve }) {
 
   requestLogger.info('request initiated');
 
-  locals.db = Database.withDefault(logger.child({ notifications: 'db' }));
+  locals.db = Database.withLogger(logger.child({ notifications: 'db' }));
   locals.dispatch = notificationDispatcher;
 
   const sid = cookies.get('sid');

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -39,7 +39,7 @@ new Worker(
   {
     connection: {
       host: BULLMQ_HOST,
-      port: Number(BULLMQ_PORT),
+      port: BULLMQ_PORT,
     },
   },
 );

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -5,7 +5,7 @@ import { pino } from 'pino';
 
 import { dev } from '$app/environment';
 
-import { BULLMQ_HOST, BULLMQ_PORT } from '$lib/server/env/bullmq';
+import { HOST, PORT } from '$lib/server/env/redis';
 import { NotificationDispatcher, queueName } from '$lib/server/email/dispatch';
 import { AssertionError } from 'assert';
 import { Database } from '$lib/server/database';
@@ -37,8 +37,8 @@ const _ = new Worker(
   ),
   {
     connection: {
-      host: BULLMQ_HOST,
-      port: BULLMQ_PORT,
+      host: HOST,
+      port: PORT,
     },
   },
 );

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -5,9 +5,9 @@ import { pino } from 'pino';
 
 import { dev } from '$app/environment';
 
+import { NotificationDispatcher, queueName } from '$lib/server/email/dispatch';
 import { JOB_CONCURRENCY } from '$lib/server/env';
 import { HOST, PORT } from '$lib/server/env/redis';
-import { NotificationDispatcher, queueName } from '$lib/server/email/dispatch';
 import { AssertionError } from 'assert';
 import { Database } from '$lib/server/database';
 import { initializeProcessor } from '$lib/server/email';

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -22,7 +22,7 @@ if (dev) {
 // This is only a base logger instance. We need to attach a request ID for each request.
 const logger = pino(stream);
 
-// This is the global email queue, it should only be attached to /api/email requests
+// This is the global email queue manager
 const notificationDispatcher = new NotificationDispatcher(
   logger.child({ notifications: 'dispatch' }),
   Database.withDefault(logger.child({ notifications: 'db' })),

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -22,19 +22,19 @@ if (dev) {
 // This is only a base logger instance. We need to attach a request ID for each request.
 const logger = pino(stream);
 
-// This is the database used by the notification system
-const notificationDB = Database.withDefault(logger.child({ notifications: 'db' }));
-
 // This is the global email queue, it should only be attached to /api/email requests
 const notificationDispatcher = new NotificationDispatcher(
   logger.child({ notifications: 'dispatch' }),
-  notificationDB,
+  Database.withDefault(logger.child({ notifications: 'db' })),
 );
 
 // This is the global email worker 
 const _ = new Worker(
   queueName,
-  initializeProcessor(notificationDB, logger.child({ notifications: 'processor' })),
+  initializeProcessor(
+    Database.withDefault(logger.child({ notifications: 'db' })), 
+    logger.child({ notifications: 'processor' })
+  ),
   {
     connection: {
       host: BULLMQ_HOST,

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -5,11 +5,11 @@ import { pino } from 'pino';
 
 import { dev } from '$app/environment';
 
+import * as REDIS from '$lib/server/env/redis';
 import { NotificationDispatcher, queueName } from '$lib/server/email/dispatch';
-import { JOB_CONCURRENCY } from '$lib/server/env';
-import { HOST, PORT } from '$lib/server/env/redis';
 import { AssertionError } from 'assert';
 import { Database } from '$lib/server/database';
+import { JOB_CONCURRENCY } from '$lib/server/env';
 import { initializeProcessor } from '$lib/server/email';
 
 // eslint-disable-next-line @typescript-eslint/init-declarations
@@ -33,8 +33,8 @@ const _ = new Worker(
   {
     concurrency: JOB_CONCURRENCY,
     connection: {
-      host: HOST,
-      port: PORT,
+      host: REDIS.HOST,
+      port: REDIS.PORT,
     },
   },
 );

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -5,7 +5,6 @@ import { pino } from 'pino';
 
 import { dev } from '$app/environment';
 
-import * as POSTGRES from '$lib/server/env/postgres';
 import { BULLMQ_HOST, BULLMQ_PORT } from '$lib/server/env/bullmq';
 import { NotificationDispatcher, queueName } from '$lib/server/email/dispatch';
 import { AssertionError } from 'assert';
@@ -24,7 +23,7 @@ if (dev) {
 const logger = pino(stream);
 
 // This is the database used by the notification system
-const notificationDB = Database.fromUrl(POSTGRES.URL, logger.child({ notifications: 'db' }));
+const notificationDB = Database.withDefault(logger.child({ notifications: 'db' }));
 
 // This is the global email queue, it should only be attached to /api/email requests
 const notificationDispatcher = new NotificationDispatcher(
@@ -56,7 +55,7 @@ export async function handle({ event, resolve }) {
 
   requestLogger.info('request initiated');
 
-  locals.db = Database.fromUrl(POSTGRES.URL, requestLogger);
+  locals.db = Database.withDefault(logger.child({ notifications: 'db' }));
   locals.dispatch = notificationDispatcher;
 
   const sid = cookies.get('sid');

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -28,12 +28,12 @@ const notificationDispatcher = new NotificationDispatcher(
   Database.withLogger(logger.child({ notifications: 'db' })),
 );
 
-// This is the global email worker 
+// This is the global email worker
 const _ = new Worker(
   queueName,
   initializeProcessor(
-    Database.withLogger(logger.child({ notifications: 'db' })), 
-    logger.child({ notifications: 'processor' })
+    Database.withLogger(logger.child({ notifications: 'db' })),
+    logger.child({ notifications: 'processor' }),
   ),
   {
     connection: {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -5,6 +5,7 @@ import { pino } from 'pino';
 
 import { dev } from '$app/environment';
 
+import { JOB_CONCURRENCY } from '$lib/server/env';
 import { HOST, PORT } from '$lib/server/env/redis';
 import { NotificationDispatcher, queueName } from '$lib/server/email/dispatch';
 import { AssertionError } from 'assert';
@@ -30,6 +31,7 @@ const _ = new Worker(
     logger.child({ notifications: 'worker' }),
   ),
   {
+    concurrency: JOB_CONCURRENCY,
     connection: {
       host: HOST,
       port: PORT,

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -31,9 +31,8 @@ const notificationDispatcher = new NotificationDispatcher(
   notificationDB,
 );
 
-// This is the global email worker
-// eslint-disable-next-line no-new
-new Worker(
+// This is the global email worker 
+const _ = new Worker(
   queueName,
   initializeProcessor(notificationDB, logger.child({ notifications: 'processor' })),
   {

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -1046,4 +1046,22 @@ export class Database implements Loggable {
 
     return result;
   }
+
+  @timed async syncResultsToUsers(draftId: number) {
+    return await this.#db
+      .update(schema.user)
+      .set({ labId: schema.facultyChoiceUser.labId })
+      .from(schema.facultyChoiceUser)
+      .where(and(
+        eq(
+          schema.facultyChoiceUser.draftId,
+          BigInt(draftId)
+        ),
+        eq(
+          schema.user.id,
+          schema.facultyChoiceUser.studentUserId
+        )
+      ))
+      .returning({ email: schema.user.email, labId: schema.user.labId });
+  }
 }

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -1046,6 +1046,7 @@ export class Database implements Loggable {
     return result;
   }
 
+  //** 'Synchronizes' user objects with draft results by assigning student-users' lab fields to their respective labs (as reflected by the faculty choices) for a given draft */
   @timed async syncResultsToUsers(draftId: bigint) {
     return await this.#db
       .update(schema.user)

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -777,20 +777,20 @@ export class Database implements Loggable {
     const query =
       typeof refreshToken === 'undefined'
         ? this.#db
-          .update(schema.candidateSender)
-          .set({ expiration, accessToken })
-          .where(eq(schema.candidateSender.userId, userId))
+            .update(schema.candidateSender)
+            .set({ expiration, accessToken })
+            .where(eq(schema.candidateSender.userId, userId))
         : this.#db
-          .insert(schema.candidateSender)
-          .values({ userId, expiration, accessToken, refreshToken })
-          .onConflictDoUpdate({
-            target: schema.candidateSender.userId,
-            set: {
-              expiration: sql`excluded.${sql.raw(schema.candidateSender.expiration.name)}`,
-              accessToken: sql`excluded.${sql.raw(schema.candidateSender.accessToken.name)}`,
-              refreshToken: sql`excluded.${sql.raw(schema.candidateSender.refreshToken.name)}`,
-            },
-          });
+            .insert(schema.candidateSender)
+            .values({ userId, expiration, accessToken, refreshToken })
+            .onConflictDoUpdate({
+              target: schema.candidateSender.userId,
+              set: {
+                expiration: sql`excluded.${sql.raw(schema.candidateSender.expiration.name)}`,
+                accessToken: sql`excluded.${sql.raw(schema.candidateSender.accessToken.name)}`,
+                refreshToken: sql`excluded.${sql.raw(schema.candidateSender.refreshToken.name)}`,
+              },
+            });
     const { rowCount } = await query;
     switch (rowCount) {
       case 1:

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -1,6 +1,18 @@
 import assert, { fail, strictEqual } from 'node:assert/strict';
 
-import { and, count, countDistinct, desc, eq, getTableColumns, gte, isNotNull, isNull, or, sql } from 'drizzle-orm';
+import {
+  and,
+  count,
+  countDistinct,
+  desc,
+  eq,
+  getTableColumns,
+  gte,
+  isNotNull,
+  isNull,
+  or,
+  sql,
+} from 'drizzle-orm';
 import type { Logger } from 'pino';
 import { drizzle } from 'drizzle-orm/node-postgres';
 

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -4,7 +4,7 @@ import { and, count, countDistinct, desc, eq, gte, isNotNull, isNull, or, sql } 
 import type { Logger } from 'pino';
 import { drizzle } from 'drizzle-orm/node-postgres';
 
-import * as postgres from '$lib/server/env/postgres';
+import * as POSTGRES from '$lib/server/env/postgres';
 import * as schema from './schema';
 import { type Loggable, timed } from './decorators';
 import { array, object, parse, string } from 'valibot';
@@ -19,7 +19,7 @@ function init(url: string) {
   return drizzle(url, { schema });
 }
 
-const staticDrizzle = init(postgres.URL);
+const staticDrizzle = init(POSTGRES.URL);
 
 function assertOptional<T>([result, ...rest]: T[]) {
   strictEqual(rest.length, 0, 'too many results');

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -1028,14 +1028,12 @@ export class Database implements Loggable {
   }
 
   @timed async markNotificationDelivered(id: string) {
-    const { returnedId } = await this.#db
+    await this.#db
       .update(schema.notification)
       .set({ deliveredAt: new Date() })
       .where(eq(schema.notification.id, id))
       .returning({ returnedId: schema.notification.id })
       .then(assertSingle);
-
-    return returnedId;
   }
 
   @timed async getNotification(id: string) {

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -1017,14 +1017,14 @@ export class Database implements Loggable {
   }
 
   @timed async insertNotification(data: Notification) {
-    const { id } = await this.#db
+    const result = await this.#db
       .insert(schema.notification)
       .values({ data })
       .returning({ id: schema.notification.id })
       .onConflictDoNothing()
-      .then(assertSingle);
+      .then(assertOptional);
 
-    return id;
+    return result;
   }
 
   @timed async markNotificationDelivered(id: string) {

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -777,20 +777,20 @@ export class Database implements Loggable {
     const query =
       typeof refreshToken === 'undefined'
         ? this.#db
-            .update(schema.candidateSender)
-            .set({ expiration, accessToken })
-            .where(eq(schema.candidateSender.userId, userId))
+          .update(schema.candidateSender)
+          .set({ expiration, accessToken })
+          .where(eq(schema.candidateSender.userId, userId))
         : this.#db
-            .insert(schema.candidateSender)
-            .values({ userId, expiration, accessToken, refreshToken })
-            .onConflictDoUpdate({
-              target: schema.candidateSender.userId,
-              set: {
-                expiration: sql`excluded.${sql.raw(schema.candidateSender.expiration.name)}`,
-                accessToken: sql`excluded.${sql.raw(schema.candidateSender.accessToken.name)}`,
-                refreshToken: sql`excluded.${sql.raw(schema.candidateSender.refreshToken.name)}`,
-              },
-            });
+          .insert(schema.candidateSender)
+          .values({ userId, expiration, accessToken, refreshToken })
+          .onConflictDoUpdate({
+            target: schema.candidateSender.userId,
+            set: {
+              expiration: sql`excluded.${sql.raw(schema.candidateSender.expiration.name)}`,
+              accessToken: sql`excluded.${sql.raw(schema.candidateSender.accessToken.name)}`,
+              refreshToken: sql`excluded.${sql.raw(schema.candidateSender.refreshToken.name)}`,
+            },
+          });
     const { rowCount } = await query;
     switch (rowCount) {
       case 1:
@@ -1057,7 +1057,10 @@ export class Database implements Loggable {
     return result;
   }
 
-  //** 'Synchronizes' user objects with draft results by assigning student-users' lab fields to their respective labs (as reflected by the faculty choices) for a given draft */
+  /**
+   * Synchronizes user objects with draft results by assigning student-users' lab fields to their
+   * respective labs (as reflected by the faculty choices) for a given draft.
+   */
   @timed async syncResultsToUsers(draftId: bigint) {
     return await this.#db
       .update(schema.user)

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -19,7 +19,7 @@ function init(url: string) {
   return drizzle(url, { schema });
 }
 
-const staticDrizzle = init(postgres.URL); 
+const staticDrizzle = init(postgres.URL);
 
 function assertOptional<T>([result, ...rest]: T[]) {
   strictEqual(rest.length, 0, 'too many results');
@@ -1052,16 +1052,12 @@ export class Database implements Loggable {
       .update(schema.user)
       .set({ labId: schema.facultyChoiceUser.labId })
       .from(schema.facultyChoiceUser)
-      .where(and(
-        eq(
-          schema.facultyChoiceUser.draftId,
-          draftId
+      .where(
+        and(
+          eq(schema.facultyChoiceUser.draftId, draftId),
+          eq(schema.user.id, schema.facultyChoiceUser.studentUserId),
         ),
-        eq(
-          schema.user.id,
-          schema.facultyChoiceUser.studentUserId
-        )
-      ))
+      )
       .returning({ user: schema.user, labId: schema.facultyChoiceUser.labId });
   }
 }

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -53,7 +53,7 @@ export class Database implements Loggable {
   }
 
   /** Constructs a Database instance using the default static drizzle instance */
-  static withDefault(logger: Logger) {
+  static withLogger(logger: Logger) {
     return new Database(logger);
   }
 

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -31,7 +31,7 @@ function init(url: string) {
   return drizzle(url, { schema });
 }
 
-const staticDrizzle = init(POSTGRES.URL);
+const database = init(POSTGRES.URL);
 
 function assertOptional<T>([result, ...rest]: T[]) {
   strictEqual(rest.length, 0, 'too many results');
@@ -59,7 +59,7 @@ export class Database implements Loggable {
   #logger: Logger;
   #db: DrizzleDatabase | DrizzleTransaction;
 
-  private constructor(logger: Logger, db: DrizzleDatabase | DrizzleTransaction = staticDrizzle) {
+  private constructor(logger: Logger, db: DrizzleDatabase | DrizzleTransaction = database) {
     this.#logger = logger;
     this.#db = db;
   }

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -1,6 +1,6 @@
 import assert, { fail, strictEqual } from 'node:assert/strict';
 
-import { and, count, countDistinct, desc, eq, gte, isNotNull, isNull, or, sql } from 'drizzle-orm';
+import { and, count, countDistinct, desc, eq, getTableColumns, gte, isNotNull, isNull, or, sql } from 'drizzle-orm';
 import type { Logger } from 'pino';
 import { drizzle } from 'drizzle-orm/node-postgres';
 
@@ -106,11 +106,13 @@ export class Database implements Loggable {
     strictEqual(rowCount, 1, 'only one session must be inserted');
   }
 
-  @timed async getUserById(id: string) {
+  @timed async getUserById(userId: string) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { id, ...rest } = getTableColumns(schema.user);
     return await this.#db
-      .select()
+      .select(rest)
       .from(schema.user)
-      .where(eq(schema.user.id, id))
+      .where(eq(schema.user.id, userId))
       .then(assertSingle);
   }
 

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -119,10 +119,9 @@ export class Database implements Loggable {
   }
 
   @timed async getUserById(userId: string) {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { id, ...rest } = getTableColumns(schema.user);
+    const { id: _, ...columns } = getTableColumns(schema.user);
     return await this.#db
-      .select(rest)
+      .select(columns)
       .from(schema.user)
       .where(eq(schema.user.id, userId))
       .then(assertSingle);

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -1047,7 +1047,7 @@ export class Database implements Loggable {
     return result;
   }
 
-  @timed async syncResultsToUsers(draftId: number) {
+  @timed async syncResultsToUsers(draftId: bigint) {
     return await this.#db
       .update(schema.user)
       .set({ labId: schema.facultyChoiceUser.labId })
@@ -1055,13 +1055,13 @@ export class Database implements Loggable {
       .where(and(
         eq(
           schema.facultyChoiceUser.draftId,
-          BigInt(draftId)
+          draftId
         ),
         eq(
           schema.user.id,
           schema.facultyChoiceUser.studentUserId
         )
       ))
-      .returning({ email: schema.user.email, labId: schema.user.labId });
+      .returning({ user: schema.user, labId: schema.facultyChoiceUser.labId });
   }
 }

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -1041,7 +1041,7 @@ export class Database implements Loggable {
       .select({ data: schema.notification.data, deliveredAt: schema.notification.deliveredAt })
       .from(schema.notification)
       .where(eq(schema.notification.id, id))
-      .then(assertSingle);
+      .then(assertOptional);
 
     return result;
   }

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -203,14 +203,13 @@ export class Database implements Loggable {
       .orderBy(({ name }) => name);
   }
 
-  @timed async getLabById(id: string) {
+  @timed async getLabById(labId: string) {
     return await this.#db
       .select({
-        id: schema.lab.id,
         name: schema.lab.name,
       })
       .from(schema.lab)
-      .where(eq(schema.lab.id, id))
+      .where(eq(schema.lab.id, labId))
       .then(assertSingle);
   }
 

--- a/src/lib/server/database/schema/email.ts
+++ b/src/lib/server/database/schema/email.ts
@@ -32,8 +32,8 @@ export const notification = email.table('notification', {
   id: ulid('id')
     .primaryKey()
     .default(sql`gen_ulid()`),
-  createdAt: timestamp('created_at', { mode: 'date' }).notNull().defaultNow(),
-  deliveredAt: timestamp('delivered_at', { mode: 'date' }),
+  createdAt: timestamp('created_at', { mode: 'date', withTimezone: true }).notNull().defaultNow(),
+  deliveredAt: timestamp('delivered_at', { mode: 'date', withTimezone: true }),
   data: jsonb('metadata').$type<Notification>().notNull(),
 });
 export type NotificationRequest = typeof notification.$inferSelect;

--- a/src/lib/server/database/schema/email.ts
+++ b/src/lib/server/database/schema/email.ts
@@ -1,4 +1,5 @@
 import { jsonb, pgSchema, text, timestamp } from 'drizzle-orm/pg-core';
+import type { Notification } from '$lib/server/models/notification';
 import { sql } from 'drizzle-orm';
 import { ulid } from './custom/ulid';
 import { user } from './app';
@@ -33,7 +34,7 @@ export const notification = email.table('notification', {
     .default(sql`gen_ulid()`),
   createdAt: timestamp('created_at', { mode: 'date' }).notNull().defaultNow(),
   deliveredAt: timestamp('delivered_at', { mode: 'date' }),
-  data: jsonb('metadata').notNull(),
+  data: jsonb('metadata').$type<Notification>().notNull(),
 });
 export type NotificationRequest = typeof notification.$inferSelect;
 export type NewNotificationRequest = typeof notification.$inferInsert;

--- a/src/lib/server/email/dispatch.ts
+++ b/src/lib/server/email/dispatch.ts
@@ -111,8 +111,7 @@ export class NotificationDispatcher implements Loggable {
     email: string,
   ) {
     const baseNotif = await this.#constructDraftNotification();
-
-    return this.#sendNotificationRequest({
+    return await this.#sendNotificationRequest({
       ...baseNotif,
       type: 'LotteryIntervention',
       labId,
@@ -125,8 +124,7 @@ export class NotificationDispatcher implements Loggable {
 
   @timed async dispatchDraftConcludedNotification() {
     const baseNotif = await this.#constructDraftNotification();
-
-    return this.#sendNotificationRequest({ ...baseNotif, type: 'Concluded' });
+    return await this.#sendNotificationRequest({ ...baseNotif, type: 'Concluded' });
   }
 
   @timed async dispatchUserNotification(user: User, labName: string, labId: string) {

--- a/src/lib/server/email/dispatch.ts
+++ b/src/lib/server/email/dispatch.ts
@@ -24,7 +24,7 @@ export class NotificationDispatcher implements Loggable {
     this.#queue = new Queue<QueuedNotification>(queueName, {
       connection: {
         host: BULLMQ_HOST,
-        port: parseInt(BULLMQ_PORT ?? '', 10),
+        port: BULLMQ_PORT,
       },
     });
 

--- a/src/lib/server/email/dispatch.ts
+++ b/src/lib/server/email/dispatch.ts
@@ -54,7 +54,15 @@ export class NotificationDispatcher implements Loggable {
 
     this.#logger.info('new notification request received', { parsedNotifRequest });
 
-    const job = await this.#queue.add(requestId, { requestId }, { jobId: requestId });
+    const job = await this.#queue.add(requestId, { requestId }, { 
+      jobId: requestId, 
+      removeOnComplete: true,
+      attempts: 3,
+      backoff: {
+        type: 'fixed',
+        delay: 3000
+      } 
+    });
 
     this.#logger.info({ job }, 'new job created');
 

--- a/src/lib/server/email/dispatch.ts
+++ b/src/lib/server/email/dispatch.ts
@@ -54,15 +54,19 @@ export class NotificationDispatcher implements Loggable {
 
     this.#logger.info('new notification request received', { parsedNotifRequest });
 
-    const job = await this.#queue.add(requestId, { requestId }, { 
-      jobId: requestId, 
-      removeOnComplete: true,
-      attempts: 3,
-      backoff: {
-        type: 'fixed',
-        delay: 3000
-      } 
-    });
+    const job = await this.#queue.add(
+      requestId,
+      { requestId },
+      {
+        jobId: requestId,
+        removeOnComplete: true,
+        attempts: 3,
+        backoff: {
+          type: 'fixed',
+          delay: 3000,
+        },
+      },
+    );
 
     this.#logger.info({ job }, 'new job created');
 

--- a/src/lib/server/email/dispatch.ts
+++ b/src/lib/server/email/dispatch.ts
@@ -63,9 +63,9 @@ export class NotificationDispatcher implements Loggable {
 
   async #constructDraftNotification(draftRound?: number | null): Promise<BaseDraftNotif> {
     const currentDraft = await this.#db.getActiveDraft();
-    
+
     this.#logger.info('new draft notification constructed');
-    
+
     if (typeof currentDraft === 'undefined') return error(500, 'unexpected draft notif call');
 
     const currentRound = typeof draftRound === 'undefined' ? currentDraft.currRound : draftRound;
@@ -79,7 +79,11 @@ export class NotificationDispatcher implements Loggable {
     return this.#sendNotificationRequest({ ...baseNotif, type: 'RoundStart' });
   }
 
-  @timed async dispatchRoundSubmittedNotif(labId: string, labName: string, draftRound?: number | null) {
+  @timed async dispatchRoundSubmittedNotif(
+    labId: string,
+    labName: string,
+    draftRound?: number | null,
+  ) {
     const baseNotif = await this.#constructDraftNotification(draftRound);
 
     return this.#sendNotificationRequest({ ...baseNotif, type: 'RoundSubmit', labName, labId });

--- a/src/lib/server/email/dispatch.ts
+++ b/src/lib/server/email/dispatch.ts
@@ -61,24 +61,26 @@ export class NotificationDispatcher implements Loggable {
     return job;
   }
 
-  async #constructDraftNotification(): Promise<BaseDraftNotif> {
+  async #constructDraftNotification(draftRound?: number | null): Promise<BaseDraftNotif> {
     const currentDraft = await this.#db.getActiveDraft();
-
+    
     this.#logger.info('new draft notification constructed');
-
+    
     if (typeof currentDraft === 'undefined') return error(500, 'unexpected draft notif call');
 
-    return { target: 'Draft', draftId: Number(currentDraft.id), round: currentDraft.currRound };
+    const currentRound = typeof draftRound === 'undefined' ? currentDraft.currRound : draftRound;
+
+    return { target: 'Draft', draftId: Number(currentDraft.id), round: currentRound };
   }
 
-  @timed async dispatchDraftRoundStartNotif() {
-    const baseNotif = await this.#constructDraftNotification();
+  @timed async dispatchDraftRoundStartNotif(draftRound?: number | null) {
+    const baseNotif = await this.#constructDraftNotification(draftRound);
 
     return this.#sendNotificationRequest({ ...baseNotif, type: 'RoundStart' });
   }
 
-  @timed async dispatchRoundSubmittedNotif(labId: string, labName: string) {
-    const baseNotif = await this.#constructDraftNotification();
+  @timed async dispatchRoundSubmittedNotif(labId: string, labName: string, draftRound?: number | null) {
+    const baseNotif = await this.#constructDraftNotification(draftRound);
 
     return this.#sendNotificationRequest({ ...baseNotif, type: 'RoundSubmit', labName, labId });
   }

--- a/src/lib/server/email/dispatch.ts
+++ b/src/lib/server/email/dispatch.ts
@@ -1,9 +1,9 @@
-import { BULLMQ_HOST, BULLMQ_PORT } from '$lib/server/env/bullmq';
 import {
   type BaseDraftNotif,
   Notification,
   QueuedNotification,
 } from '$lib/server/models/notification';
+import { HOST, PORT } from '$lib/server/env/redis';
 import { type Loggable, timed } from '$lib/server/database/decorators';
 import { Queue, QueueEvents } from 'bullmq';
 import type { Database } from '$lib/server/database';
@@ -23,8 +23,8 @@ export class NotificationDispatcher implements Loggable {
   constructor(logger: Logger, db: Database) {
     this.#queue = new Queue<QueuedNotification>(queueName, {
       connection: {
-        host: BULLMQ_HOST,
-        port: BULLMQ_PORT,
+        host: HOST,
+        port: PORT,
       },
     });
 

--- a/src/lib/server/email/dispatch.ts
+++ b/src/lib/server/email/dispatch.ts
@@ -84,23 +84,26 @@ export class NotificationDispatcher implements Loggable {
     return { target: 'Draft', draftId: currentDraft.id, round: currentRound };
   }
 
-  @timed async dispatchDraftRoundStartNotif(draftRound?: number | null) {
+  @timed async dispatchDraftRoundStartNotification(draftRound?: number | null) {
     const baseNotif = await this.#constructDraftNotification(draftRound);
-
-    return this.#sendNotificationRequest({ ...baseNotif, type: 'RoundStart' });
+    return await this.#sendNotificationRequest({ ...baseNotif, type: 'RoundStart' });
   }
 
-  @timed async dispatchRoundSubmittedNotif(
+  @timed async dispatchRoundSubmittedNotification(
     labId: string,
     labName: string,
     draftRound?: number | null,
   ) {
     const baseNotif = await this.#constructDraftNotification(draftRound);
-
-    return this.#sendNotificationRequest({ ...baseNotif, type: 'RoundSubmit', labName, labId });
+    return await this.#sendNotificationRequest({
+      ...baseNotif,
+      type: 'RoundSubmit',
+      labName,
+      labId,
+    });
   }
 
-  @timed async dispatchLotteryInterventionNotif(
+  @timed async dispatchLotteryInterventionNotification(
     labId: string,
     labName: string,
     givenName: string,
@@ -120,13 +123,13 @@ export class NotificationDispatcher implements Loggable {
     });
   }
 
-  @timed async dispatchDraftConcludedNotif() {
+  @timed async dispatchDraftConcludedNotification() {
     const baseNotif = await this.#constructDraftNotification();
 
     return this.#sendNotificationRequest({ ...baseNotif, type: 'Concluded' });
   }
 
-  @timed async dispatchUserNotif(user: User, labName: string, labId: string) {
+  @timed async dispatchUserNotification(user: User, labName: string, labId: string) {
     return await this.#sendNotificationRequest({
       target: 'User',
       email: user.email,

--- a/src/lib/server/email/dispatch.ts
+++ b/src/lib/server/email/dispatch.ts
@@ -50,7 +50,10 @@ export class NotificationDispatcher implements Loggable {
     // one last sanity check to gatekeep the queue
     const parsedNotifRequest = parse(Notification, notifRequest);
 
-    const requestId = await this.#db.insertNotification(parsedNotifRequest);
+    const request = await this.#db.insertNotification(parsedNotifRequest);
+
+    if (typeof request === 'undefined') return;
+    const { id: requestId } = request;
 
     this.#logger.info('new notification request received', { parsedNotifRequest });
 

--- a/src/lib/server/email/dispatch.ts
+++ b/src/lib/server/email/dispatch.ts
@@ -81,7 +81,7 @@ export class NotificationDispatcher implements Loggable {
 
     const currentRound = typeof draftRound === 'undefined' ? currentDraft.currRound : draftRound;
 
-    return { target: 'Draft', draftId: Number(currentDraft.id), round: currentRound };
+    return { target: 'Draft', draftId: currentDraft.id, round: currentRound };
   }
 
   @timed async dispatchDraftRoundStartNotif(draftRound?: number | null) {

--- a/src/lib/server/email/dispatch.ts
+++ b/src/lib/server/email/dispatch.ts
@@ -32,18 +32,14 @@ export class NotificationDispatcher implements Loggable {
     this.#db = db;
     this.#logger = logger;
 
-    this.#queueEvents.on('completed', this.#onCompleted.bind(this));
-    this.#queueEvents.on('failed', this.#onFailed.bind(this));
+    this.#queueEvents.on('completed', ({ jobId }) => {
+      this.#logger.info('email job completed', jobId);
+    });
+    this.#queueEvents.on('failed', ({ jobId }) => {
+      this.#logger.error('email job failed', jobId);
+    });
 
     this.#logger.info('email queue setup complete');
-  }
-
-  #onCompleted(args: { jobId: string }) {
-    this.#logger.info('email job completed', args);
-  }
-
-  #onFailed(args: { jobId: string }) {
-    this.#logger.error('email job failed', args);
   }
 
   async #sendNotificationRequest(notifRequest: Notification) {

--- a/src/lib/server/email/index.ts
+++ b/src/lib/server/email/index.ts
@@ -90,6 +90,13 @@ export class Emailer {
   }
 }
 
+class NotificationProcessingError extends Error {
+  constructor (message: string) {
+    super(message);
+    this.name = "NotificationProcessingError";
+  }
+}
+
 export function initializeProcessor(db: Database, logger: Logger) {
   const emailer = new Emailer(db, GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET);
 
@@ -192,14 +199,14 @@ export function initializeProcessor(db: Database, logger: Logger) {
           }
           default: {
             logger.error('unknown notification request target');
-            throw Error('unknown notification request target');
+            throw new NotificationProcessingError('unknown notification request target');
           }
         }
       })();
 
       if (result === null) {
         logger.error('no designated sender configured');
-        throw Error('no designated sender configured');
+        throw new NotificationProcessingError('no designated sender configured');
       }
 
       await txn.markNotificationDelivered(requestId);

--- a/src/lib/server/email/index.ts
+++ b/src/lib/server/email/index.ts
@@ -151,21 +151,17 @@ export function initializeProcessor(db: Database, logger: Logger) {
     })();
     assert(meta !== null);
 
-    const email = await emailer.send(await meta.emails, meta.subject, meta.message);
-
-    return email;
+    return await emailer.send(await meta.emails, meta.subject, meta.message);
   }
 
-  function processUserNotification(notifRequest: Notification, emailer: Emailer) {
+  async function processUserNotification(notifRequest: Notification, emailer: Emailer) {
     assert(notifRequest.target === 'User');
 
-    const email = emailer.send(
+    return await emailer.send(
       [notifRequest.email],
       `[DRAP] Assigned to ${notifRequest.labId.toUpperCase()}`,
       `Hello, ${notifRequest.givenName} ${notifRequest.familyName}! Kindly note that you have been assigned to the ${notifRequest.labName}.`,
     );
-
-    return email;
   }
 
   return async function processor(job: Job<QueuedNotification>) {

--- a/src/lib/server/email/index.ts
+++ b/src/lib/server/email/index.ts
@@ -173,7 +173,13 @@ export function initializeProcessor(db: Database, logger: Logger) {
       data: { requestId },
     } = job;
 
-    const { data, deliveredAt } = await emailer.db.getNotification(requestId);
+    const notification = await emailer.db.getNotification(requestId);
+
+    if (typeof notification === 'undefined') {
+      logger.warn('attempted to process nonexistent notification');
+      return;
+    }
+    const { data, deliveredAt } = notification;
 
     if (deliveredAt !== null) {
       logger.warn('attempted to process delivered notification');

--- a/src/lib/server/email/index.ts
+++ b/src/lib/server/email/index.ts
@@ -1,7 +1,7 @@
 import type { Database, schema } from '$lib/server/database';
+import { DraftNotification, Notification, UserNotification, type QueuedNotification } from '$lib/server/models/notification';
 import { GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET } from '$env/static/private';
 import { IdToken, TokenResponse } from '$lib/server/models/oauth';
-import { DraftNotification, Notification, UserNotification, type QueuedNotification } from '$lib/server/models/notification';
 import assert, { strictEqual } from 'node:assert/strict';
 import { isFuture, sub } from 'date-fns';
 import { parse, pick } from 'valibot';
@@ -175,7 +175,7 @@ export function initializeProcessor(db: Database, logger: Logger) {
     const { data, deliveredAt } = notification;
 
     if (deliveredAt !== null) {
-      logger.warn('attempted to process delivered notification');
+      logger.warn({ deliveredAt }, 'attempted to process delivered notification');
       return;
     }
 

--- a/src/lib/server/email/index.ts
+++ b/src/lib/server/email/index.ts
@@ -1,5 +1,10 @@
 import type { Database, schema } from '$lib/server/database';
-import { DraftNotification, Notification, type QueuedNotification, UserNotification } from '$lib/server/models/notification';
+import {
+  DraftNotification,
+  Notification,
+  type QueuedNotification,
+  UserNotification,
+} from '$lib/server/models/notification';
 import { GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET } from '$env/static/private';
 import { IdToken, TokenResponse } from '$lib/server/models/oauth';
 import assert, { strictEqual } from 'node:assert/strict';
@@ -91,9 +96,9 @@ export class Emailer {
 }
 
 class NotificationProcessingError extends Error {
-  constructor (message: string) {
+  constructor(message: string) {
     super(message);
-    this.name = "NotificationProcessingError";
+    this.name = 'NotificationProcessingError';
   }
 }
 

--- a/src/lib/server/email/index.ts
+++ b/src/lib/server/email/index.ts
@@ -116,13 +116,13 @@ export function initializeProcessor(db: Database, logger: Logger) {
           const body =
             notifRequest.round === null
               ? {
-                  subject: `[DRAP] Lottery Round for Draft #${notifRequest.draftId} has begun!`,
-                  message: `The lottery round for Draft #${notifRequest.draftId} has begun. For lab heads, kindly coordinate with the draft administrators for the next steps.`,
-                }
+                subject: `[DRAP] Lottery Round for Draft #${notifRequest.draftId} has begun!`,
+                message: `The lottery round for Draft #${notifRequest.draftId} has begun. For lab heads, kindly coordinate with the draft administrators for the next steps.`,
+              }
               : {
-                  subject: `[DRAP] Round #${notifRequest.round} for Draft #${notifRequest.draftId} has begun!`,
-                  message: `Round #${notifRequest.round} for Draft #${notifRequest.draftId} has begun. For lab heads, kindly check the students module to see the list of students who have chosen your lab.`,
-                };
+                subject: `[DRAP] Round #${notifRequest.round} for Draft #${notifRequest.draftId} has begun!`,
+                message: `Round #${notifRequest.round} for Draft #${notifRequest.draftId} has begun. For lab heads, kindly check the students module to see the list of students who have chosen your lab.`,
+              };
           const facultyAndStaffEmails = txn
             .getFacultyAndStaff()
             .then(result => result.map(({ email }) => email));
@@ -194,7 +194,8 @@ export function initializeProcessor(db: Database, logger: Logger) {
     const notifRequest = parse(Notification, data);
 
     emailer.db.begin(async txn => {
-      let result: Awaited<ReturnType<typeof processDraftNotification>> = null;
+      // eslint-disable-next-line @typescript-eslint/init-declarations
+      let result: Awaited<ReturnType<typeof processDraftNotification>>;
       switch (notifRequest.target) {
         case 'Draft': {
           result = await processDraftNotification(notifRequest, txn, emailer);

--- a/src/lib/server/email/index.ts
+++ b/src/lib/server/email/index.ts
@@ -193,12 +193,12 @@ export function initializeProcessor(db: Database, logger: Logger) {
 
     const notifRequest = parse(Notification, data);
 
-    emailer.db.begin(async txn => {
+    emailer.db.begin(async db => {
       // eslint-disable-next-line @typescript-eslint/init-declarations
       let result: Awaited<ReturnType<typeof processDraftNotification>>;
       switch (notifRequest.target) {
         case 'Draft': {
-          result = await processDraftNotification(notifRequest, txn, emailer);
+          result = await processDraftNotification(notifRequest, db, emailer);
           break;
         }
         case 'User': {
@@ -216,7 +216,7 @@ export function initializeProcessor(db: Database, logger: Logger) {
         throw new NotificationProcessingError('no designated sender configured');
       }
 
-      await txn.markNotificationDelivered(requestId);
+      await db.markNotificationDelivered(requestId);
     });
   };
 }

--- a/src/lib/server/email/index.ts
+++ b/src/lib/server/email/index.ts
@@ -1,3 +1,4 @@
+import * as GOOGLE from '$lib/server/env/google';
 import type { Database, schema } from '$lib/server/database';
 import {
   DraftNotification,
@@ -5,7 +6,6 @@ import {
   type QueuedNotification,
   UserNotification,
 } from '$lib/server/models/notification';
-import { GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET } from '$env/static/private';
 import { IdToken, TokenResponse } from '$lib/server/models/oauth';
 import assert, { strictEqual } from 'node:assert/strict';
 import { isFuture, sub } from 'date-fns';
@@ -103,7 +103,7 @@ class NotificationProcessingError extends Error {
 }
 
 export function initializeProcessor(db: Database, logger: Logger) {
-  const emailer = new Emailer(db, GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET);
+  const emailer = new Emailer(db, GOOGLE.OAUTH_CLIENT_ID, GOOGLE.OAUTH_CLIENT_SECRET);
 
   async function processDraftNotification(
     notifRequest: DraftNotification,

--- a/src/lib/server/email/index.ts
+++ b/src/lib/server/email/index.ts
@@ -116,13 +116,13 @@ export function initializeProcessor(db: Database, logger: Logger) {
           const body =
             notifRequest.round === null
               ? {
-                subject: `[DRAP] Lottery Round for Draft #${notifRequest.draftId} has begun!`,
-                message: `The lottery round for Draft #${notifRequest.draftId} has begun. For lab heads, kindly coordinate with the draft administrators for the next steps.`,
-              }
+                  subject: `[DRAP] Lottery Round for Draft #${notifRequest.draftId} has begun!`,
+                  message: `The lottery round for Draft #${notifRequest.draftId} has begun. For lab heads, kindly coordinate with the draft administrators for the next steps.`,
+                }
               : {
-                subject: `[DRAP] Round #${notifRequest.round} for Draft #${notifRequest.draftId} has begun!`,
-                message: `Round #${notifRequest.round} for Draft #${notifRequest.draftId} has begun. For lab heads, kindly check the students module to see the list of students who have chosen your lab.`,
-              };
+                  subject: `[DRAP] Round #${notifRequest.round} for Draft #${notifRequest.draftId} has begun!`,
+                  message: `Round #${notifRequest.round} for Draft #${notifRequest.draftId} has begun. For lab heads, kindly check the students module to see the list of students who have chosen your lab.`,
+                };
           const facultyAndStaffEmails = txn
             .getFacultyAndStaff()
             .then(result => result.map(({ email }) => email));

--- a/src/lib/server/env/bullmq.js
+++ b/src/lib/server/env/bullmq.js
@@ -11,4 +11,4 @@ if (building) {
 }
 
 export const BULLMQ_HOST = env.REDIS_HOST;
-export const BULLMQ_PORT = env.REDIS_PORT;
+export const BULLMQ_PORT = Number.parseInt(env.REDIS_PORT, 10);

--- a/src/lib/server/env/google.js
+++ b/src/lib/server/env/google.js
@@ -11,6 +11,6 @@ if (building) {
   assert(typeof env.GOOGLE_OAUTH_REDIRECT_URI !== 'undefined');
 }
 
-export const OAUTH_CLIENT_ID = env.GOOGLE_OAUTH_CLIENT_ID;
-export const OAUTH_CLIENT_SECRET = env.GOOGLE_OAUTH_CLIENT_SECRET;
-export const OAUTH_REDIRECT_URI = env.GOOGLE_OAUTH_REDIRECT_URI;
+export const OAUTH_CLIENT_ID = env.GOOGLE_OAUTH_CLIENT_ID ?? '';
+export const OAUTH_CLIENT_SECRET = env.GOOGLE_OAUTH_CLIENT_SECRET ?? '';
+export const OAUTH_REDIRECT_URI = env.GOOGLE_OAUTH_REDIRECT_URI ?? '';

--- a/src/lib/server/env/index.ts
+++ b/src/lib/server/env/index.ts
@@ -1,0 +1,9 @@
+import { env } from '$env/dynamic/private';
+
+// eslint-disable-next-line @typescript-eslint/init-declarations
+let jobConcurrency: number | undefined;
+if (typeof env.JOB_CONCURRENCY !== 'undefined')
+  jobConcurrency = Number.parseInt(env.JOB_CONCURRENCY, 10);
+
+/** Maximum number of email worker jobs to run concurrently. */
+export const JOB_CONCURRENCY = jobConcurrency;

--- a/src/lib/server/env/postgres.js
+++ b/src/lib/server/env/postgres.js
@@ -9,4 +9,4 @@ if (building) {
   assert(typeof env.POSTGRES_URL !== 'undefined');
 }
 
-export const URL = env.POSTGRES_URL;
+export const URL = env.POSTGRES_URL ?? '';

--- a/src/lib/server/env/redis.js
+++ b/src/lib/server/env/redis.js
@@ -10,5 +10,5 @@ if (building) {
   assert(typeof env.REDIS_PORT !== 'undefined');
 }
 
-export const BULLMQ_HOST = env.REDIS_HOST;
-export const BULLMQ_PORT = Number.parseInt(env.REDIS_PORT, 10);
+export const HOST = env.REDIS_HOST;
+export const PORT = Number.parseInt(env.REDIS_PORT, 10);

--- a/src/lib/server/env/redis.js
+++ b/src/lib/server/env/redis.js
@@ -10,5 +10,5 @@ if (building) {
   assert(typeof env.REDIS_PORT !== 'undefined');
 }
 
-export const HOST = env.REDIS_HOST;
-export const PORT = Number.parseInt(env.REDIS_PORT, 10);
+export const HOST = env.REDIS_HOST ?? '';
+export const PORT = env.REDIS_PORT ? Number.parseInt(env.REDIS_PORT, 10) : Number.NaN;

--- a/src/lib/server/models/email.ts
+++ b/src/lib/server/models/email.ts
@@ -1,4 +1,4 @@
-import { type InferOutput, array, object, string } from 'valibot';
+import { type InferOutput, array, email, object, pipe, string } from 'valibot';
 
 export const GmailMessageSendResult = object({
   id: string(),
@@ -9,7 +9,7 @@ export const GmailMessageSendResult = object({
 export type GmailMessageSendResult = InferOutput<typeof GmailMessageSendResult>;
 
 export const EmailSendRequest = object({
-  to: array(string()),
+  to: array(pipe(string(), email())),
   subject: string(),
   data: string(),
 });

--- a/src/lib/server/models/notification.ts
+++ b/src/lib/server/models/notification.ts
@@ -8,6 +8,7 @@ import {
   object,
   pipe,
   string,
+  uuid,
   variant,
 } from 'valibot';
 
@@ -75,7 +76,7 @@ export const Notification = variant('target', [DraftNotification, UserNotificati
 export type Notification = InferOutput<typeof Notification>;
 
 export const QueuedNotification = object({
-  requestId: string(),
+  requestId: pipe(string(), uuid()),
 });
 
 export type QueuedNotification = InferOutput<typeof QueuedNotification>;

--- a/src/lib/server/models/notification.ts
+++ b/src/lib/server/models/notification.ts
@@ -58,10 +58,10 @@ const BaseUserNotif = object({
 export type BaseUserNotif = InferOutput<typeof BaseUserNotif>;
 
 export const DraftNotification = variant('type', [
-    DraftRoundStartedNotif,
-    DraftRoundSubmittedNotif,
-    LotteryInterventionNotif,
-    DraftConcludedNotif,
+  DraftRoundStartedNotif,
+  DraftRoundSubmittedNotif,
+  LotteryInterventionNotif,
+  DraftConcludedNotif,
 ]);
 
 export type DraftNotification = InferOutput<typeof DraftNotification>;
@@ -70,10 +70,7 @@ export const UserNotification = BaseUserNotif;
 
 export type UserNotification = InferOutput<typeof UserNotification>;
 
-export const Notification = variant('target', [
-  DraftNotification,
-  UserNotification
-]);
+export const Notification = variant('target', [DraftNotification, UserNotification]);
 
 export type Notification = InferOutput<typeof Notification>;
 

--- a/src/lib/server/models/notification.ts
+++ b/src/lib/server/models/notification.ts
@@ -1,5 +1,6 @@
 import {
   type InferOutput,
+  bigint,
   email,
   literal,
   nullable,
@@ -12,7 +13,7 @@ import {
 
 const BaseDraftNotif = object({
   target: literal('Draft'),
-  draftId: number(),
+  draftId: bigint(),
   round: nullable(number()),
 });
 

--- a/src/lib/server/models/notification.ts
+++ b/src/lib/server/models/notification.ts
@@ -57,14 +57,22 @@ const BaseUserNotif = object({
 
 export type BaseUserNotif = InferOutput<typeof BaseUserNotif>;
 
-export const Notification = variant('target', [
-  variant('type', [
+export const DraftNotification = variant('type', [
     DraftRoundStartedNotif,
     DraftRoundSubmittedNotif,
     LotteryInterventionNotif,
     DraftConcludedNotif,
-  ]),
-  BaseUserNotif,
+]);
+
+export type DraftNotification = InferOutput<typeof DraftNotification>;
+
+export const UserNotification = BaseUserNotif;
+
+export type UserNotification = InferOutput<typeof UserNotification>;
+
+export const Notification = variant('target', [
+  DraftNotification,
+  UserNotification
 ]);
 
 export type Notification = InferOutput<typeof Notification>;

--- a/src/routes/dashboard/(admin)/drafts/+page.server.ts
+++ b/src/routes/dashboard/(admin)/drafts/+page.server.ts
@@ -126,13 +126,6 @@ export const actions = {
         assert(typeof incrementDraftRound !== 'undefined', 'cannot start a non-existent draft');
         db.logger.info(incrementDraftRound, 'draft round incremented');
 
-        // TODO: Reinstate notifications channel.
-        // const postDraftRoundStartedNotification = await db.postDraftRoundStartedNotification(
-        //     draft,
-        //     incrementDraftRound.currRound,
-        // );
-        // db.logger.info({ postDraftRoundStartedNotification });
-        // await db.notifyDraftChannel();
         deferredNotifications.push(incrementDraftRound.currRound);
 
         // Pause at the lottery rounds
@@ -188,9 +181,6 @@ export const actions = {
 
     await db.begin(async db => {
       await db.insertLotteryChoices(draftId, user.id, pairs);
-      // TODO: Reinstate notifications channel.
-      // await db.postLotteryInterventionNotifications(draft, pairs);
-      // await db.notifyDraftChannel();
     });
 
     for (const [studentUserId, labId] of pairs) {
@@ -247,9 +237,7 @@ export const actions = {
           );
           throw ZIP_NOT_EQUAL;
         }
-
-        // TODO: Reinstate notifications channel.
-        // await db.postLotteryInterventionNotifications(draft, pairs);
+        
         const pairs = zip(emails, schedule);
         deferredNotifications = pairs;
 
@@ -264,15 +252,8 @@ export const actions = {
         const concludeDraft = await db.concludeDraft(draftId);
         db.logger.info({ concludeDraft }, 'draft concluded');
 
-        // TODO: Reinstate notifications channel.
-        // await db.postDraftConcluded(draft);
-        // const syncDraftResultsToUsers = await db.syncDraftResultsToUsersWithNotification(draft);
         draftResults = await db.syncResultsToUsers(draftId);
-        // db.logger.info({ syncDraftResultsToUsers });
-
-        // TODO: Reinstate notifications channel.
-        // await db.notifyDraftChannel();
-        // await db.notifyUserChannel();
+        db.logger.info({ draftResults }, 'draft results synced');
       });
     } catch (err) {
       if (err === ZIP_NOT_EQUAL) return fail(403);

--- a/src/routes/dashboard/(admin)/drafts/+page.server.ts
+++ b/src/routes/dashboard/(admin)/drafts/+page.server.ts
@@ -237,7 +237,7 @@ export const actions = {
           );
           throw ZIP_NOT_EQUAL;
         }
-        
+
         const pairs = zip(emails, schedule);
         deferredNotifications = pairs;
 
@@ -261,7 +261,10 @@ export const actions = {
     }
 
     for (const [studentUserId, labId] of deferredNotifications) {
-      const [{ name: labName }, studentUser] = await Promise.all([db.getLabById(labId), db.getUserById(studentUserId)]);
+      const [{ name: labName }, studentUser] = await Promise.all([
+        db.getLabById(labId),
+        db.getUserById(studentUserId),
+      ]);
       dispatch.dispatchLotteryInterventionNotif(
         labId,
         labName,

--- a/src/routes/dashboard/(admin)/drafts/+page.server.ts
+++ b/src/routes/dashboard/(admin)/drafts/+page.server.ts
@@ -117,6 +117,8 @@ export const actions = {
       return fail(497);
     }
 
+    const deferredNotifications: (number | null)[] = [];
+
     await db.begin(async db => {
       while (true) {
         const incrementDraftRound = await db.incrementDraftRound(draftId);
@@ -130,7 +132,7 @@ export const actions = {
         // );
         // db.logger.info({ postDraftRoundStartedNotification });
         // await db.notifyDraftChannel();
-        dispatch.dispatchDraftRoundStartNotif();
+        deferredNotifications.push(incrementDraftRound.currRound);
 
         // Pause at the lottery rounds
         if (incrementDraftRound.currRound === null) {
@@ -148,6 +150,9 @@ export const actions = {
         }
       }
     });
+
+    for (const round of deferredNotifications) 
+      dispatch.dispatchDraftRoundStartNotif(round);
 
     db.logger.info('draft officially started');
   },

--- a/src/routes/dashboard/(admin)/drafts/+page.server.ts
+++ b/src/routes/dashboard/(admin)/drafts/+page.server.ts
@@ -146,7 +146,7 @@ export const actions = {
     });
 
     for (const round of deferredNotifications)
-      await dispatch.dispatchDraftRoundStartNotification(round);
+      await dispatch.dispatchDraftRoundStartNotification(draftId, round);
 
     db.logger.info('draft officially started');
   },
@@ -190,6 +190,7 @@ export const actions = {
         studentUser.givenName,
         studentUser.familyName,
         studentUser.email,
+        draftId
       );
     }
 
@@ -269,6 +270,7 @@ export const actions = {
         studentUser.givenName,
         studentUser.familyName,
         studentUser.email,
+        draftId
       );
     }
 
@@ -277,7 +279,7 @@ export const actions = {
       await dispatch.dispatchUserNotification(user, name, labId);
     }
 
-    await dispatch.dispatchDraftConcludedNotification();
+    await dispatch.dispatchDraftConcludedNotification(draftId);
 
     redirect(303, `/history/${draftId}/`);
   },

--- a/src/routes/dashboard/(admin)/drafts/+page.server.ts
+++ b/src/routes/dashboard/(admin)/drafts/+page.server.ts
@@ -190,7 +190,7 @@ export const actions = {
         studentUser.givenName,
         studentUser.familyName,
         studentUser.email,
-        draftId
+        draftId,
       );
     }
 
@@ -270,7 +270,7 @@ export const actions = {
         studentUser.givenName,
         studentUser.familyName,
         studentUser.email,
-        draftId
+        draftId,
       );
     }
 

--- a/src/routes/dashboard/(admin)/drafts/+page.server.ts
+++ b/src/routes/dashboard/(admin)/drafts/+page.server.ts
@@ -145,7 +145,7 @@ export const actions = {
       }
     });
 
-    for (const round of deferredNotifications) dispatch.dispatchDraftRoundStartNotif(round);
+    for (const round of deferredNotifications) dispatch.dispatchDraftRoundStartNotification(round);
 
     db.logger.info('draft officially started');
   },
@@ -186,7 +186,7 @@ export const actions = {
     for (const [studentUserId, labId] of pairs) {
       const { name: labName } = await db.getLabById(labId);
       const studentUser = await db.getUserById(studentUserId);
-      dispatch.dispatchLotteryInterventionNotif(
+      dispatch.dispatchLotteryInterventionNotification(
         labId,
         labName,
         studentUser.givenName,
@@ -265,7 +265,7 @@ export const actions = {
         db.getLabById(labId),
         db.getUserById(studentUserId),
       ]);
-      dispatch.dispatchLotteryInterventionNotif(
+      dispatch.dispatchLotteryInterventionNotification(
         labId,
         labName,
         studentUser.givenName,
@@ -276,9 +276,9 @@ export const actions = {
 
     for (const { user, labId } of draftResults) {
       const { name } = await db.getLabById(labId);
-      dispatch.dispatchUserNotif(user, name, labId);
+      dispatch.dispatchUserNotification(user, name, labId);
     }
-    dispatch.dispatchDraftConcludedNotif();
+    dispatch.dispatchDraftConcludedNotification();
 
     redirect(303, `/history/${draftId}/`);
   },

--- a/src/routes/dashboard/(admin)/drafts/+page.server.ts
+++ b/src/routes/dashboard/(admin)/drafts/+page.server.ts
@@ -152,8 +152,7 @@ export const actions = {
       }
     });
 
-    for (const round of deferredNotifications) 
-      dispatch.dispatchDraftRoundStartNotif(round);
+    for (const round of deferredNotifications) dispatch.dispatchDraftRoundStartNotif(round);
 
     db.logger.info('draft officially started');
   },
@@ -193,7 +192,7 @@ export const actions = {
       // await db.postLotteryInterventionNotifications(draft, pairs);
       // await db.notifyDraftChannel();
     });
-    
+
     for (const [studentUserId, labId] of pairs) {
       const { name: labName } = await db.getLabById(labId);
       const studentUser = await db.getUserById(studentUserId);
@@ -230,7 +229,7 @@ export const actions = {
     // TODO: Assert that we are indeed in the lottery phase.
 
     let deferredNotifications: [string, string][] = [];
-    let draftResults: { user: User, labId: string }[] = [];
+    let draftResults: { user: User; labId: string }[] = [];
 
     try {
       await db.begin(async db => {
@@ -292,7 +291,7 @@ export const actions = {
       );
     }
 
-    for (const {user, labId} of draftResults) {
+    for (const { user, labId } of draftResults) {
       const { name } = await db.getLabById(labId);
       dispatch.dispatchUserNotif(user, name, labId);
     }

--- a/src/routes/dashboard/(admin)/drafts/+page.server.ts
+++ b/src/routes/dashboard/(admin)/drafts/+page.server.ts
@@ -145,7 +145,8 @@ export const actions = {
       }
     });
 
-    for (const round of deferredNotifications) dispatch.dispatchDraftRoundStartNotification(round);
+    for (const round of deferredNotifications)
+      await dispatch.dispatchDraftRoundStartNotification(round);
 
     db.logger.info('draft officially started');
   },
@@ -179,14 +180,11 @@ export const actions = {
 
     db.logger.info({ pairs }, 'intervening draft');
 
-    await db.begin(async db => {
-      await db.insertLotteryChoices(draftId, user.id, pairs);
-    });
-
+    await db.insertLotteryChoices(draftId, user.id, pairs);
     for (const [studentUserId, labId] of pairs) {
       const { name: labName } = await db.getLabById(labId);
       const studentUser = await db.getUserById(studentUserId);
-      dispatch.dispatchLotteryInterventionNotification(
+      await dispatch.dispatchLotteryInterventionNotification(
         labId,
         labName,
         studentUser.givenName,
@@ -265,7 +263,7 @@ export const actions = {
         db.getLabById(labId),
         db.getUserById(studentUserId),
       ]);
-      dispatch.dispatchLotteryInterventionNotification(
+      await dispatch.dispatchLotteryInterventionNotification(
         labId,
         labName,
         studentUser.givenName,
@@ -276,9 +274,10 @@ export const actions = {
 
     for (const { user, labId } of draftResults) {
       const { name } = await db.getLabById(labId);
-      dispatch.dispatchUserNotification(user, name, labId);
+      await dispatch.dispatchUserNotification(user, name, labId);
     }
-    dispatch.dispatchDraftConcludedNotification();
+
+    await dispatch.dispatchDraftConcludedNotification();
 
     redirect(303, `/history/${draftId}/`);
   },

--- a/src/routes/dashboard/(admin)/drafts/+page.server.ts
+++ b/src/routes/dashboard/(admin)/drafts/+page.server.ts
@@ -261,8 +261,7 @@ export const actions = {
     }
 
     for (const [studentUserId, labId] of deferredNotifications) {
-      const { name: labName } = await db.getLabById(labId);
-      const studentUser = await db.getUserById(studentUserId);
+      const [{ name: labName }, studentUser] = await Promise.all([db.getLabById(labId), db.getUserById(studentUserId)]);
       dispatch.dispatchLotteryInterventionNotif(
         labId,
         labName,

--- a/src/routes/dashboard/(draft)/students/+page.server.js
+++ b/src/routes/dashboard/(draft)/students/+page.server.js
@@ -84,10 +84,6 @@ export const actions = {
       await db.insertFacultyChoice(draftId, lab, faculty, students);
       db.logger.info({ studentCount: students.length }, 'students inserted into faculty choice');
 
-      // TODO: Reinstate notifications channel.
-      // const postDraftRoundSubmittedNotification = await db.postDraftRoundSubmittedNotification(draft, lab);
-      // db.logger.info({ postDraftRoundSubmittedNotification });
-
       while (true) {
         const count = await db.getPendingLabCountInDraft(draftId);
         if (count > 0) {
@@ -102,12 +98,6 @@ export const actions = {
         );
         db.logger.info(incrementDraftRound, 'draft round incremented');
 
-        // TODO: Reinstate notifications channel.
-        // const postDraftRoundStartedNotification = await db.postDraftRoundStartedNotification(
-        //     draft,
-        //     incrementDraftRound.curr_round,
-        // );
-        // db.logger.info({ postDraftRoundStartedNotification });
         deferredNotifications.push(incrementDraftRound.currRound);
 
         if (incrementDraftRound.currRound === null) {
@@ -118,9 +108,6 @@ export const actions = {
         await db.autoAcknowledgeLabsWithoutPreferences(draftId);
         db.logger.info('labs without preferences auto-acknowledged');
       }
-
-      // TODO: Do notification as final step to ensure consistency
-      // await db.notifyDraftChannel();
     });
 
     // assume the first round referenced in the deferred notifications is the round for which the notification was sent 

--- a/src/routes/dashboard/(draft)/students/+page.server.ts
+++ b/src/routes/dashboard/(draft)/students/+page.server.ts
@@ -111,9 +111,10 @@ export const actions = {
     });
 
     // assume the first round referenced in the deferred notifications is the round for which the notification was sent
-    dispatch.dispatchRoundSubmittedNotification(lab, name, deferredNotifications[0]);
+    await dispatch.dispatchRoundSubmittedNotification(lab, name, deferredNotifications[0]);
 
     db.logger.info('student rankings submitted');
-    for (const round of deferredNotifications) dispatch.dispatchDraftRoundStartNotification(round);
+    for (const round of deferredNotifications)
+      await dispatch.dispatchDraftRoundStartNotification(round);
   },
 };

--- a/src/routes/dashboard/(draft)/students/+page.server.ts
+++ b/src/routes/dashboard/(draft)/students/+page.server.ts
@@ -111,9 +111,9 @@ export const actions = {
     });
 
     // assume the first round referenced in the deferred notifications is the round for which the notification was sent
-    dispatch.dispatchRoundSubmittedNotif(lab, name, deferredNotifications[0]);
+    dispatch.dispatchRoundSubmittedNotification(lab, name, deferredNotifications[0]);
 
     db.logger.info('student rankings submitted');
-    for (const round of deferredNotifications) dispatch.dispatchDraftRoundStartNotif(round);
+    for (const round of deferredNotifications) dispatch.dispatchDraftRoundStartNotification(round);
   },
 };

--- a/src/routes/dashboard/(draft)/students/+page.server.ts
+++ b/src/routes/dashboard/(draft)/students/+page.server.ts
@@ -1,5 +1,6 @@
 import { error, redirect } from '@sveltejs/kit';
 import assert from 'node:assert/strict';
+import { strict } from 'node:assert';
 import { validateString } from '$lib/forms';
 
 export async function load({ locals: { db, session }, parent }) {
@@ -110,11 +111,14 @@ export const actions = {
       }
     });
 
+    // assert that deferredNotifications (the array of all round numbers to be notified for) has at least one entry
+    strict(typeof deferredNotifications[0] !== 'undefined');
+
     // assume the first round referenced in the deferred notifications is the round for which the notification was sent
-    await dispatch.dispatchRoundSubmittedNotification(lab, name, deferredNotifications[0]);
+    await dispatch.dispatchRoundSubmittedNotification(lab, name, draftId, deferredNotifications[0]);
 
     db.logger.info('student rankings submitted');
     for (const round of deferredNotifications)
-      await dispatch.dispatchDraftRoundStartNotification(round);
+      await dispatch.dispatchDraftRoundStartNotification(draftId, round);
   },
 };

--- a/src/routes/dashboard/(draft)/students/+page.server.ts
+++ b/src/routes/dashboard/(draft)/students/+page.server.ts
@@ -110,11 +110,10 @@ export const actions = {
       }
     });
 
-    // assume the first round referenced in the deferred notifications is the round for which the notification was sent 
+    // assume the first round referenced in the deferred notifications is the round for which the notification was sent
     dispatch.dispatchRoundSubmittedNotif(lab, name, deferredNotifications[0]);
-    
+
     db.logger.info('student rankings submitted');
-    for (const round of deferredNotifications) 
-      dispatch.dispatchDraftRoundStartNotif(round);
+    for (const round of deferredNotifications) dispatch.dispatchDraftRoundStartNotif(round);
   },
 };

--- a/src/routes/dashboard/email/+page.server.js
+++ b/src/routes/dashboard/email/+page.server.js
@@ -86,10 +86,8 @@ export const actions = {
     const userId = validateString(data.get('user-id'));
     db.logger.info({ senderUserId: userId }, 'promoting sender');
 
-    await db.begin(async db => {
-      const upsertDesignatedSender = await db.upsertDesignatedSender(userId);
-      db.logger.info({ upsertDesignatedSender }, 'sender promoted as designated sender');
-    });
+    const upsertDesignatedSender = await db.upsertDesignatedSender(userId);
+    db.logger.info({ upsertDesignatedSender }, 'sender promoted as designated sender');
   },
   async remove({ locals: { db, session }, request }) {
     if (typeof session?.user === 'undefined') {

--- a/src/routes/dashboard/email/+page.server.js
+++ b/src/routes/dashboard/email/+page.server.js
@@ -89,9 +89,6 @@ export const actions = {
     await db.begin(async db => {
       const upsertDesignatedSender = await db.upsertDesignatedSender(userId);
       db.logger.info({ upsertDesignatedSender }, 'sender promoted as designated sender');
-      // TODO: Reinstate notifications channel.
-      // await db.notifyDraftChannel();
-      // await db.notifyUserChannel();
     });
   },
   async remove({ locals: { db, session }, request }) {


### PR DESCRIPTION
This PR reactivates the email notification system for DRAP, this time making use of a BullMQ message queue instead of using the database as a queue. This will require the introduction of a new Redis service to our stack, with corresponding environment secrets.

Aside from that, this PR also changes how `Database` objects are instantiated, by default using a single drizzle adapter instance across all instances.