### PR TITLE
feat: add healthcheck for services www and redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,10 @@ services:
       - .env
     healthcheck:
       test: ["CMD-SHELL", "wget -q0- http://localhost:3000/"]
-      interval: 1m30s
+      interval: 10s
       timeout: 30s
       retries: 5
-      start_period: 30s
+      start_period: 10s
   db:
     build: ./docker/postgres
     profiles:
@@ -42,6 +42,12 @@ services:
       - redis:/data
     ports:
       - 6379:6379
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 30s
+      retries: 5
+      start_period: 10s
 volumes:
   postgres:
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,12 @@ services:
       - 3000:3000
     env_file:
       - .env
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q0- http://localhost:3000/"]
+      interval: 1m30s
+      timeout: 30s
+      retries: 5
+      start_period: 30s
   db:
     build: ./docker/postgres
     profiles:


### PR DESCRIPTION
This PR adds health checks for the `www` and `redis` services under the `docker-compose.yml`. For `www`, I figure just checking the homepage would suffice for a health check, considering how the other dependencies _should_ have been loaded successfully at the system's start.

Maybe there would be some benefit though in checking on the state of the database in any future `/api/health`