### PR TITLE
fix: rewrite deduplication and filtering logic for lab logs

### DIFF
--- a/src/routes/dashboard/(admin)/drafts/SystemLogsTab.svelte
+++ b/src/routes/dashboard/(admin)/drafts/SystemLogsTab.svelte
@@ -58,7 +58,7 @@ Needs to distinguish the following events (one 'event' being a grouping of choic
       const [labId, round] = key.split('|');
       assert(typeof round !== 'undefined');
       assert(typeof labId !== 'undefined');
-      return [labId, round === 'null' ? null : parseInt(round, 10)];
+      return [labId, round.length === 0 ? null : Number.parseInt(round, 10)];
     },
   )}
   <div class="card my-2 space-y-4 p-2">


### PR DESCRIPTION
Whoops, reused this branch for a PR.

This PR corrects some flaws in the original automation logs display logic. First, the filters are redesigned to remove specifically `event`s which are automation logs (instead of whole swaths of logs which were mixed automation and selection logs as before). Second, the deduplication that coalesces multiple selection/automation events for a single lab was rewritten to discriminate on `{labId, round}` instead of just `labId`, which was causing simultaneous events from one lab (i.e. when a lab submitted and filled up its quota for all succeeding rounds) to coalesce.