### PR TITLE
feat: add draft registration closing

### DIFF
--- a/drizzle/0015_add_registration_closes_at.sql
+++ b/drizzle/0015_add_registration_closes_at.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "drap"."draft" ADD COLUMN "registration_closes_at" timestamp with time zone NOT NULL;
+ALTER TABLE "drap"."draft" ADD COLUMN "registration_closes_at" timestamp with time zone;

--- a/drizzle/0015_add_registration_closes_at.sql
+++ b/drizzle/0015_add_registration_closes_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "drap"."draft" ADD COLUMN "registration_closes_at" timestamp with time zone;

--- a/drizzle/0015_add_registration_closes_at.sql
+++ b/drizzle/0015_add_registration_closes_at.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "drap"."draft" ADD COLUMN "registration_closes_at" timestamp with time zone;
+ALTER TABLE "drap"."draft" ADD COLUMN "registration_closes_at" timestamp with time zone NOT NULL;

--- a/drizzle/0016_backfill-registration-closes-at.sql
+++ b/drizzle/0016_backfill-registration-closes-at.sql
@@ -1,0 +1,1 @@
+UPDATE "drap"."draft" SET "registration_closes_at" = upper("active_period") WHERE upper("drap"."draft"."active_period") IS NOT NULL;

--- a/drizzle/0017_non-null-registration-closes-at.sql
+++ b/drizzle/0017_non-null-registration-closes-at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "drap"."draft" ALTER COLUMN "registration_closes_at" SET NOT NULL;

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "e5598ac5-3d91-4fbb-9eac-1e63e4df0ce9",
+  "id": "946f55e7-059d-4c83-8d4f-4049e094babf",
   "prevId": "654c92fd-9ec2-48ad-a56c-89ab71065f7c",
   "version": "7",
   "dialect": "postgresql",
@@ -42,7 +42,7 @@
           "name": "registration_closes_at",
           "type": "timestamp with time zone",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
         },
         "active_period": {
           "name": "active_period",

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,998 @@
+{
+  "id": "946f55e7-059d-4c83-8d4f-4049e094babf",
+  "prevId": "654c92fd-9ec2-48ad-a56c-89ab71065f7c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "drap.draft": {
+      "name": "draft",
+      "schema": "drap",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "draft_id_seq",
+            "schema": "drap",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "curr_round": {
+          "name": "curr_round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "max_rounds": {
+          "name": "max_rounds",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_closes_at": {
+          "name": "registration_closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_period": {
+          "name": "active_period",
+          "type": "tstzrange",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "tstzrange(now(), null, '[)')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "draft_curr_round_within_bounds": {
+          "name": "draft_curr_round_within_bounds",
+          "value": "\"drap\".\"draft\".\"curr_round\" BETWEEN 0 AND \"drap\".\"draft\".\"max_rounds\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "drap.faculty_choice": {
+      "name": "faculty_choice",
+      "schema": "drap",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "faculty_choice_draft_id_draft_id_fk": {
+          "name": "faculty_choice_draft_id_draft_id_fk",
+          "tableFrom": "faculty_choice",
+          "tableTo": "draft",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "faculty_choice_lab_id_lab_lab_id_fk": {
+          "name": "faculty_choice_lab_id_lab_lab_id_fk",
+          "tableFrom": "faculty_choice",
+          "tableTo": "lab",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "lab_id"
+          ],
+          "columnsTo": [
+            "lab_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "faculty_choice_user_id_user_id_fk": {
+          "name": "faculty_choice_user_id_user_id_fk",
+          "tableFrom": "faculty_choice",
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "faculty_choice_only_once_per_draft_round": {
+          "name": "faculty_choice_only_once_per_draft_round",
+          "nullsNotDistinct": true,
+          "columns": [
+            "draft_id",
+            "round",
+            "lab_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "faculty_choice_post_registration_round_check": {
+          "name": "faculty_choice_post_registration_round_check",
+          "value": "\"drap\".\"faculty_choice\".\"round\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "drap.faculty_choice_user": {
+      "name": "faculty_choice_user",
+      "schema": "drap",
+      "columns": {
+        "faculty_user_id": {
+          "name": "faculty_user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_user_id": {
+          "name": "student_user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "faculty_choice_user_faculty_user_id_user_id_fk": {
+          "name": "faculty_choice_user_faculty_user_id_user_id_fk",
+          "tableFrom": "faculty_choice_user",
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "faculty_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "faculty_choice_user_student_user_id_user_id_fk": {
+          "name": "faculty_choice_user_student_user_id_user_id_fk",
+          "tableFrom": "faculty_choice_user",
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "student_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "faculty_choice_user_draft_id_draft_id_fk": {
+          "name": "faculty_choice_user_draft_id_draft_id_fk",
+          "tableFrom": "faculty_choice_user",
+          "tableTo": "draft",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "faculty_choice_user_lab_id_lab_lab_id_fk": {
+          "name": "faculty_choice_user_lab_id_lab_lab_id_fk",
+          "tableFrom": "faculty_choice_user",
+          "tableTo": "lab",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "lab_id"
+          ],
+          "columnsTo": [
+            "lab_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "faculty_choice_user_draft_id_round_lab_id_faculty_choice_draft_id_round_lab_id_fk": {
+          "name": "faculty_choice_user_draft_id_round_lab_id_faculty_choice_draft_id_round_lab_id_fk",
+          "tableFrom": "faculty_choice_user",
+          "tableTo": "faculty_choice",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "draft_id",
+            "round",
+            "lab_id"
+          ],
+          "columnsTo": [
+            "draft_id",
+            "round",
+            "lab_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "faculty_choice_user_unique_student_selection_per_draft": {
+          "name": "faculty_choice_user_unique_student_selection_per_draft",
+          "nullsNotDistinct": false,
+          "columns": [
+            "draft_id",
+            "student_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "faculty_choice_user_different_student_and_faculty_users": {
+          "name": "faculty_choice_user_different_student_and_faculty_users",
+          "value": "\"drap\".\"faculty_choice_user\".\"student_user_id\" <> \"drap\".\"faculty_choice_user\".\"faculty_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "drap.lab": {
+      "name": "lab",
+      "schema": "drap",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lab_name": {
+          "name": "lab_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quota": {
+          "name": "quota",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lab_lab_name_unique": {
+          "name": "lab_lab_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lab_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "lab_quota_non_negative_check": {
+          "name": "lab_quota_non_negative_check",
+          "value": "\"drap\".\"lab\".\"quota\" >= 0"
+        },
+        "lab_id_no_commas_check": {
+          "name": "lab_id_no_commas_check",
+          "value": "POSITION(',' IN \"drap\".\"lab\".\"lab_id\") = 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "drap.student_rank": {
+      "name": "student_rank",
+      "schema": "drap",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "student_rank_draft_id_draft_id_fk": {
+          "name": "student_rank_draft_id_draft_id_fk",
+          "tableFrom": "student_rank",
+          "tableTo": "draft",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "student_rank_user_id_user_id_fk": {
+          "name": "student_rank_user_id_user_id_fk",
+          "tableFrom": "student_rank",
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "student_rank_draft_id_user_id_pk": {
+          "name": "student_rank_draft_id_user_id_pk",
+          "columns": [
+            "draft_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "drap.student_rank_lab": {
+      "name": "student_rank_lab",
+      "schema": "drap",
+      "columns": {
+        "draft_id": {
+          "name": "draft_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remark": {
+          "name": "remark",
+          "type": "varchar(1028)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "student_rank_lab_draft_id_draft_id_fk": {
+          "name": "student_rank_lab_draft_id_draft_id_fk",
+          "tableFrom": "student_rank_lab",
+          "tableTo": "draft",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "student_rank_lab_user_id_user_id_fk": {
+          "name": "student_rank_lab_user_id_user_id_fk",
+          "tableFrom": "student_rank_lab",
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "student_rank_lab_lab_id_lab_lab_id_fk": {
+          "name": "student_rank_lab_lab_id_lab_lab_id_fk",
+          "tableFrom": "student_rank_lab",
+          "tableTo": "lab",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "lab_id"
+          ],
+          "columnsTo": [
+            "lab_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "student_rank_lab_draft_id_user_id_lab_id_pk": {
+          "name": "student_rank_lab_draft_id_user_id_lab_id_pk",
+          "columns": [
+            "draft_id",
+            "user_id",
+            "lab_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "drap.user": {
+      "name": "user",
+      "schema": "drap",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_ulid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "google_user_id": {
+          "name": "google_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "given_name": {
+          "name": "given_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "family_name": {
+          "name": "family_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_lab_id_lab_lab_id_fk": {
+          "name": "user_lab_id_lab_lab_id_fk",
+          "tableFrom": "user",
+          "tableTo": "lab",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "lab_id"
+          ],
+          "columnsTo": [
+            "lab_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_student_number_unique": {
+          "name": "user_student_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "student_number"
+          ]
+        },
+        "user_google_user_id_unique": {
+          "name": "user_google_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_user_id"
+          ]
+        },
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_student_number_within_bounds": {
+          "name": "user_student_number_within_bounds",
+          "value": "\"drap\".\"user\".\"student_number\" BETWEEN 100000000 AND 1000000000"
+        },
+        "user_email_non_empty": {
+          "name": "user_email_non_empty",
+          "value": "\"drap\".\"user\".\"email\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "auth.pending": {
+      "name": "pending",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_ulid()"
+        },
+        "expiration": {
+          "name": "expiration",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now() + INTERVAL '15 minutes'"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_bytes(64)"
+        },
+        "has_extended_scope": {
+          "name": "has_extended_scope",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.session": {
+      "name": "session",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_ulid()"
+        },
+        "expiration": {
+          "name": "expiration",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "email.candidate_sender": {
+      "name": "candidate_sender",
+      "schema": "email",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiration": {
+          "name": "expiration",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "candidate_sender_user_id_user_id_fk": {
+          "name": "candidate_sender_user_id_user_id_fk",
+          "tableFrom": "candidate_sender",
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "email.designated_sender": {
+      "name": "designated_sender",
+      "schema": "email",
+      "columns": {
+        "candidate_sender_user_id": {
+          "name": "candidate_sender_user_id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "designated_sender_candidate_sender_user_id_candidate_sender_user_id_fk": {
+          "name": "designated_sender_candidate_sender_user_id_candidate_sender_user_id_fk",
+          "tableFrom": "designated_sender",
+          "tableTo": "candidate_sender",
+          "schemaTo": "email",
+          "columnsFrom": [
+            "candidate_sender_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "email.notification": {
+      "name": "notification",
+      "schema": "email",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_ulid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "drap": "drap",
+    "auth": "auth",
+    "email": "email"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "drap.active_lab_view": {
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lab_name": {
+          "name": "lab_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quota": {
+          "name": "quota",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"created_at\", \"lab_id\", \"lab_name\", \"quota\", \"deleted_at\" from \"drap\".\"lab\" where \"drap\".\"lab\".\"deleted_at\" is null",
+      "name": "active_lab_view",
+      "schema": "drap",
+      "isExisting": false,
+      "materialized": false
+    },
+    "drap.lab_member_view": {
+      "columns": {
+        "student_user_id": {
+          "name": "student_user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "given_name": {
+          "name": "given_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "family_name": {
+          "name": "family_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"drap\".\"faculty_choice_user\".\"student_user_id\", \"drap\".\"faculty_choice_user\".\"draft_id\", \"drap\".\"faculty_choice_user\".\"lab_id\" as \"draft_lab\", \"drap\".\"user\".\"lab_id\" as \"user_lab\", \"drap\".\"user\".\"email\", \"drap\".\"user\".\"given_name\", \"drap\".\"user\".\"family_name\", \"drap\".\"user\".\"avatar\", \"drap\".\"user\".\"student_number\" from \"drap\".\"user\" right join \"drap\".\"faculty_choice_user\" on \"drap\".\"user\".\"id\" = \"drap\".\"faculty_choice_user\".\"student_user_id\"",
+      "name": "lab_member_view",
+      "schema": "drap",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "946f55e7-059d-4c83-8d4f-4049e094babf",
+  "id": "e5598ac5-3d91-4fbb-9eac-1e63e4df0ce9",
   "prevId": "654c92fd-9ec2-48ad-a56c-89ab71065f7c",
   "version": "7",
   "dialect": "postgresql",
@@ -42,7 +42,7 @@
           "name": "registration_closes_at",
           "type": "timestamp with time zone",
           "primaryKey": false,
-          "notNull": false
+          "notNull": true
         },
         "active_period": {
           "name": "active_period",

--- a/drizzle/meta/0016_snapshot.json
+++ b/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,998 @@
+{
+  "id": "66dcd0ad-7adb-43d8-a0fc-bef267e78350",
+  "prevId": "946f55e7-059d-4c83-8d4f-4049e094babf",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "drap.draft": {
+      "name": "draft",
+      "schema": "drap",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "draft_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "drap",
+            "type": "always"
+          }
+        },
+        "curr_round": {
+          "name": "curr_round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "max_rounds": {
+          "name": "max_rounds",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_closes_at": {
+          "name": "registration_closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_period": {
+          "name": "active_period",
+          "type": "tstzrange",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "tstzrange(now(), null, '[)')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "draft_curr_round_within_bounds": {
+          "name": "draft_curr_round_within_bounds",
+          "value": "\"drap\".\"draft\".\"curr_round\" BETWEEN 0 AND \"drap\".\"draft\".\"max_rounds\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "drap.faculty_choice": {
+      "name": "faculty_choice",
+      "schema": "drap",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "faculty_choice_draft_id_draft_id_fk": {
+          "name": "faculty_choice_draft_id_draft_id_fk",
+          "tableFrom": "faculty_choice",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "tableTo": "draft",
+          "schemaTo": "drap",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "no action"
+        },
+        "faculty_choice_lab_id_lab_lab_id_fk": {
+          "name": "faculty_choice_lab_id_lab_lab_id_fk",
+          "tableFrom": "faculty_choice",
+          "columnsFrom": [
+            "lab_id"
+          ],
+          "tableTo": "lab",
+          "schemaTo": "drap",
+          "columnsTo": [
+            "lab_id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "no action"
+        },
+        "faculty_choice_user_id_user_id_fk": {
+          "name": "faculty_choice_user_id_user_id_fk",
+          "tableFrom": "faculty_choice",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "faculty_choice_only_once_per_draft_round": {
+          "name": "faculty_choice_only_once_per_draft_round",
+          "columns": [
+            "draft_id",
+            "round",
+            "lab_id"
+          ],
+          "nullsNotDistinct": true
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "faculty_choice_post_registration_round_check": {
+          "name": "faculty_choice_post_registration_round_check",
+          "value": "\"drap\".\"faculty_choice\".\"round\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "drap.faculty_choice_user": {
+      "name": "faculty_choice_user",
+      "schema": "drap",
+      "columns": {
+        "faculty_user_id": {
+          "name": "faculty_user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_user_id": {
+          "name": "student_user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "faculty_choice_user_faculty_user_id_user_id_fk": {
+          "name": "faculty_choice_user_faculty_user_id_user_id_fk",
+          "tableFrom": "faculty_choice_user",
+          "columnsFrom": [
+            "faculty_user_id"
+          ],
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "no action"
+        },
+        "faculty_choice_user_student_user_id_user_id_fk": {
+          "name": "faculty_choice_user_student_user_id_user_id_fk",
+          "tableFrom": "faculty_choice_user",
+          "columnsFrom": [
+            "student_user_id"
+          ],
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "no action"
+        },
+        "faculty_choice_user_draft_id_draft_id_fk": {
+          "name": "faculty_choice_user_draft_id_draft_id_fk",
+          "tableFrom": "faculty_choice_user",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "tableTo": "draft",
+          "schemaTo": "drap",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "no action"
+        },
+        "faculty_choice_user_lab_id_lab_lab_id_fk": {
+          "name": "faculty_choice_user_lab_id_lab_lab_id_fk",
+          "tableFrom": "faculty_choice_user",
+          "columnsFrom": [
+            "lab_id"
+          ],
+          "tableTo": "lab",
+          "schemaTo": "drap",
+          "columnsTo": [
+            "lab_id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "no action"
+        },
+        "faculty_choice_user_draft_id_round_lab_id_faculty_choice_draft_id_round_lab_id_fk": {
+          "name": "faculty_choice_user_draft_id_round_lab_id_faculty_choice_draft_id_round_lab_id_fk",
+          "tableFrom": "faculty_choice_user",
+          "columnsFrom": [
+            "draft_id",
+            "round",
+            "lab_id"
+          ],
+          "tableTo": "faculty_choice",
+          "schemaTo": "drap",
+          "columnsTo": [
+            "draft_id",
+            "round",
+            "lab_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "faculty_choice_user_unique_student_selection_per_draft": {
+          "name": "faculty_choice_user_unique_student_selection_per_draft",
+          "columns": [
+            "draft_id",
+            "student_user_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "faculty_choice_user_different_student_and_faculty_users": {
+          "name": "faculty_choice_user_different_student_and_faculty_users",
+          "value": "\"drap\".\"faculty_choice_user\".\"student_user_id\" <> \"drap\".\"faculty_choice_user\".\"faculty_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "drap.lab": {
+      "name": "lab",
+      "schema": "drap",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lab_name": {
+          "name": "lab_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quota": {
+          "name": "quota",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lab_lab_name_unique": {
+          "name": "lab_lab_name_unique",
+          "columns": [
+            "lab_name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "lab_quota_non_negative_check": {
+          "name": "lab_quota_non_negative_check",
+          "value": "\"drap\".\"lab\".\"quota\" >= 0"
+        },
+        "lab_id_no_commas_check": {
+          "name": "lab_id_no_commas_check",
+          "value": "POSITION(',' IN \"drap\".\"lab\".\"lab_id\") = 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "drap.student_rank": {
+      "name": "student_rank",
+      "schema": "drap",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "student_rank_draft_id_draft_id_fk": {
+          "name": "student_rank_draft_id_draft_id_fk",
+          "tableFrom": "student_rank",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "tableTo": "draft",
+          "schemaTo": "drap",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "no action"
+        },
+        "student_rank_user_id_user_id_fk": {
+          "name": "student_rank_user_id_user_id_fk",
+          "tableFrom": "student_rank",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "student_rank_draft_id_user_id_pk": {
+          "name": "student_rank_draft_id_user_id_pk",
+          "columns": [
+            "draft_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "drap.student_rank_lab": {
+      "name": "student_rank_lab",
+      "schema": "drap",
+      "columns": {
+        "draft_id": {
+          "name": "draft_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remark": {
+          "name": "remark",
+          "type": "varchar(1028)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "student_rank_lab_draft_id_draft_id_fk": {
+          "name": "student_rank_lab_draft_id_draft_id_fk",
+          "tableFrom": "student_rank_lab",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "tableTo": "draft",
+          "schemaTo": "drap",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "no action"
+        },
+        "student_rank_lab_user_id_user_id_fk": {
+          "name": "student_rank_lab_user_id_user_id_fk",
+          "tableFrom": "student_rank_lab",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "no action"
+        },
+        "student_rank_lab_lab_id_lab_lab_id_fk": {
+          "name": "student_rank_lab_lab_id_lab_lab_id_fk",
+          "tableFrom": "student_rank_lab",
+          "columnsFrom": [
+            "lab_id"
+          ],
+          "tableTo": "lab",
+          "schemaTo": "drap",
+          "columnsTo": [
+            "lab_id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "student_rank_lab_draft_id_user_id_lab_id_pk": {
+          "name": "student_rank_lab_draft_id_user_id_lab_id_pk",
+          "columns": [
+            "draft_id",
+            "user_id",
+            "lab_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "drap.user": {
+      "name": "user",
+      "schema": "drap",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_ulid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "google_user_id": {
+          "name": "google_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "given_name": {
+          "name": "given_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "family_name": {
+          "name": "family_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_lab_id_lab_lab_id_fk": {
+          "name": "user_lab_id_lab_lab_id_fk",
+          "tableFrom": "user",
+          "columnsFrom": [
+            "lab_id"
+          ],
+          "tableTo": "lab",
+          "schemaTo": "drap",
+          "columnsTo": [
+            "lab_id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_student_number_unique": {
+          "name": "user_student_number_unique",
+          "columns": [
+            "student_number"
+          ],
+          "nullsNotDistinct": false
+        },
+        "user_google_user_id_unique": {
+          "name": "user_google_user_id_unique",
+          "columns": [
+            "google_user_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_student_number_within_bounds": {
+          "name": "user_student_number_within_bounds",
+          "value": "\"drap\".\"user\".\"student_number\" BETWEEN 100000000 AND 1000000000"
+        },
+        "user_email_non_empty": {
+          "name": "user_email_non_empty",
+          "value": "\"drap\".\"user\".\"email\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "auth.pending": {
+      "name": "pending",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_ulid()"
+        },
+        "expiration": {
+          "name": "expiration",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now() + INTERVAL '15 minutes'"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_bytes(64)"
+        },
+        "has_extended_scope": {
+          "name": "has_extended_scope",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.session": {
+      "name": "session",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_ulid()"
+        },
+        "expiration": {
+          "name": "expiration",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "email.candidate_sender": {
+      "name": "candidate_sender",
+      "schema": "email",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiration": {
+          "name": "expiration",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "candidate_sender_user_id_user_id_fk": {
+          "name": "candidate_sender_user_id_user_id_fk",
+          "tableFrom": "candidate_sender",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "email.designated_sender": {
+      "name": "designated_sender",
+      "schema": "email",
+      "columns": {
+        "candidate_sender_user_id": {
+          "name": "candidate_sender_user_id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "designated_sender_candidate_sender_user_id_candidate_sender_user_id_fk": {
+          "name": "designated_sender_candidate_sender_user_id_candidate_sender_user_id_fk",
+          "tableFrom": "designated_sender",
+          "columnsFrom": [
+            "candidate_sender_user_id"
+          ],
+          "tableTo": "candidate_sender",
+          "schemaTo": "email",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "email.notification": {
+      "name": "notification",
+      "schema": "email",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_ulid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "drap": "drap",
+    "auth": "auth",
+    "email": "email"
+  },
+  "views": {
+    "drap.active_lab_view": {
+      "name": "active_lab_view",
+      "schema": "drap",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lab_name": {
+          "name": "lab_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quota": {
+          "name": "quota",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"created_at\", \"lab_id\", \"lab_name\", \"quota\", \"deleted_at\" from \"drap\".\"lab\" where \"drap\".\"lab\".\"deleted_at\" is null",
+      "materialized": false,
+      "isExisting": false
+    },
+    "drap.lab_member_view": {
+      "name": "lab_member_view",
+      "schema": "drap",
+      "columns": {
+        "student_user_id": {
+          "name": "student_user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "given_name": {
+          "name": "given_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "family_name": {
+          "name": "family_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"drap\".\"faculty_choice_user\".\"student_user_id\", \"drap\".\"faculty_choice_user\".\"draft_id\", \"drap\".\"faculty_choice_user\".\"lab_id\" as \"draft_lab\", \"drap\".\"user\".\"lab_id\" as \"user_lab\", \"drap\".\"user\".\"email\", \"drap\".\"user\".\"given_name\", \"drap\".\"user\".\"family_name\", \"drap\".\"user\".\"avatar\", \"drap\".\"user\".\"student_number\" from \"drap\".\"user\" right join \"drap\".\"faculty_choice_user\" on \"drap\".\"user\".\"id\" = \"drap\".\"faculty_choice_user\".\"student_user_id\"",
+      "materialized": false,
+      "isExisting": false
+    }
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0017_snapshot.json
+++ b/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,998 @@
+{
+  "id": "32e54d9e-eaa8-49c9-b27f-4215e790f426",
+  "prevId": "66dcd0ad-7adb-43d8-a0fc-bef267e78350",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "drap.draft": {
+      "name": "draft",
+      "schema": "drap",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "draft_id_seq",
+            "schema": "drap",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "curr_round": {
+          "name": "curr_round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "max_rounds": {
+          "name": "max_rounds",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_closes_at": {
+          "name": "registration_closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_period": {
+          "name": "active_period",
+          "type": "tstzrange",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "tstzrange(now(), null, '[)')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "draft_curr_round_within_bounds": {
+          "name": "draft_curr_round_within_bounds",
+          "value": "\"drap\".\"draft\".\"curr_round\" BETWEEN 0 AND \"drap\".\"draft\".\"max_rounds\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "drap.faculty_choice": {
+      "name": "faculty_choice",
+      "schema": "drap",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "faculty_choice_draft_id_draft_id_fk": {
+          "name": "faculty_choice_draft_id_draft_id_fk",
+          "tableFrom": "faculty_choice",
+          "tableTo": "draft",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "faculty_choice_lab_id_lab_lab_id_fk": {
+          "name": "faculty_choice_lab_id_lab_lab_id_fk",
+          "tableFrom": "faculty_choice",
+          "tableTo": "lab",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "lab_id"
+          ],
+          "columnsTo": [
+            "lab_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "faculty_choice_user_id_user_id_fk": {
+          "name": "faculty_choice_user_id_user_id_fk",
+          "tableFrom": "faculty_choice",
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "faculty_choice_only_once_per_draft_round": {
+          "name": "faculty_choice_only_once_per_draft_round",
+          "nullsNotDistinct": true,
+          "columns": [
+            "draft_id",
+            "round",
+            "lab_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "faculty_choice_post_registration_round_check": {
+          "name": "faculty_choice_post_registration_round_check",
+          "value": "\"drap\".\"faculty_choice\".\"round\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "drap.faculty_choice_user": {
+      "name": "faculty_choice_user",
+      "schema": "drap",
+      "columns": {
+        "faculty_user_id": {
+          "name": "faculty_user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_user_id": {
+          "name": "student_user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "faculty_choice_user_faculty_user_id_user_id_fk": {
+          "name": "faculty_choice_user_faculty_user_id_user_id_fk",
+          "tableFrom": "faculty_choice_user",
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "faculty_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "faculty_choice_user_student_user_id_user_id_fk": {
+          "name": "faculty_choice_user_student_user_id_user_id_fk",
+          "tableFrom": "faculty_choice_user",
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "student_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "faculty_choice_user_draft_id_draft_id_fk": {
+          "name": "faculty_choice_user_draft_id_draft_id_fk",
+          "tableFrom": "faculty_choice_user",
+          "tableTo": "draft",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "faculty_choice_user_lab_id_lab_lab_id_fk": {
+          "name": "faculty_choice_user_lab_id_lab_lab_id_fk",
+          "tableFrom": "faculty_choice_user",
+          "tableTo": "lab",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "lab_id"
+          ],
+          "columnsTo": [
+            "lab_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "faculty_choice_user_draft_id_round_lab_id_faculty_choice_draft_id_round_lab_id_fk": {
+          "name": "faculty_choice_user_draft_id_round_lab_id_faculty_choice_draft_id_round_lab_id_fk",
+          "tableFrom": "faculty_choice_user",
+          "tableTo": "faculty_choice",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "draft_id",
+            "round",
+            "lab_id"
+          ],
+          "columnsTo": [
+            "draft_id",
+            "round",
+            "lab_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "faculty_choice_user_unique_student_selection_per_draft": {
+          "name": "faculty_choice_user_unique_student_selection_per_draft",
+          "nullsNotDistinct": false,
+          "columns": [
+            "draft_id",
+            "student_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "faculty_choice_user_different_student_and_faculty_users": {
+          "name": "faculty_choice_user_different_student_and_faculty_users",
+          "value": "\"drap\".\"faculty_choice_user\".\"student_user_id\" <> \"drap\".\"faculty_choice_user\".\"faculty_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "drap.lab": {
+      "name": "lab",
+      "schema": "drap",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lab_name": {
+          "name": "lab_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quota": {
+          "name": "quota",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lab_lab_name_unique": {
+          "name": "lab_lab_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lab_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "lab_quota_non_negative_check": {
+          "name": "lab_quota_non_negative_check",
+          "value": "\"drap\".\"lab\".\"quota\" >= 0"
+        },
+        "lab_id_no_commas_check": {
+          "name": "lab_id_no_commas_check",
+          "value": "POSITION(',' IN \"drap\".\"lab\".\"lab_id\") = 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "drap.student_rank": {
+      "name": "student_rank",
+      "schema": "drap",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "student_rank_draft_id_draft_id_fk": {
+          "name": "student_rank_draft_id_draft_id_fk",
+          "tableFrom": "student_rank",
+          "tableTo": "draft",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "student_rank_user_id_user_id_fk": {
+          "name": "student_rank_user_id_user_id_fk",
+          "tableFrom": "student_rank",
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "student_rank_draft_id_user_id_pk": {
+          "name": "student_rank_draft_id_user_id_pk",
+          "columns": [
+            "draft_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "drap.student_rank_lab": {
+      "name": "student_rank_lab",
+      "schema": "drap",
+      "columns": {
+        "draft_id": {
+          "name": "draft_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remark": {
+          "name": "remark",
+          "type": "varchar(1028)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "student_rank_lab_draft_id_draft_id_fk": {
+          "name": "student_rank_lab_draft_id_draft_id_fk",
+          "tableFrom": "student_rank_lab",
+          "tableTo": "draft",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "student_rank_lab_user_id_user_id_fk": {
+          "name": "student_rank_lab_user_id_user_id_fk",
+          "tableFrom": "student_rank_lab",
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "student_rank_lab_lab_id_lab_lab_id_fk": {
+          "name": "student_rank_lab_lab_id_lab_lab_id_fk",
+          "tableFrom": "student_rank_lab",
+          "tableTo": "lab",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "lab_id"
+          ],
+          "columnsTo": [
+            "lab_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "student_rank_lab_draft_id_user_id_lab_id_pk": {
+          "name": "student_rank_lab_draft_id_user_id_lab_id_pk",
+          "columns": [
+            "draft_id",
+            "user_id",
+            "lab_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "drap.user": {
+      "name": "user",
+      "schema": "drap",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_ulid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "google_user_id": {
+          "name": "google_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "given_name": {
+          "name": "given_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "family_name": {
+          "name": "family_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_lab_id_lab_lab_id_fk": {
+          "name": "user_lab_id_lab_lab_id_fk",
+          "tableFrom": "user",
+          "tableTo": "lab",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "lab_id"
+          ],
+          "columnsTo": [
+            "lab_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_student_number_unique": {
+          "name": "user_student_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "student_number"
+          ]
+        },
+        "user_google_user_id_unique": {
+          "name": "user_google_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_user_id"
+          ]
+        },
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_student_number_within_bounds": {
+          "name": "user_student_number_within_bounds",
+          "value": "\"drap\".\"user\".\"student_number\" BETWEEN 100000000 AND 1000000000"
+        },
+        "user_email_non_empty": {
+          "name": "user_email_non_empty",
+          "value": "\"drap\".\"user\".\"email\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "auth.pending": {
+      "name": "pending",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_ulid()"
+        },
+        "expiration": {
+          "name": "expiration",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now() + INTERVAL '15 minutes'"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_bytes(64)"
+        },
+        "has_extended_scope": {
+          "name": "has_extended_scope",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.session": {
+      "name": "session",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_ulid()"
+        },
+        "expiration": {
+          "name": "expiration",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "email.candidate_sender": {
+      "name": "candidate_sender",
+      "schema": "email",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiration": {
+          "name": "expiration",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "candidate_sender_user_id_user_id_fk": {
+          "name": "candidate_sender_user_id_user_id_fk",
+          "tableFrom": "candidate_sender",
+          "tableTo": "user",
+          "schemaTo": "drap",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "email.designated_sender": {
+      "name": "designated_sender",
+      "schema": "email",
+      "columns": {
+        "candidate_sender_user_id": {
+          "name": "candidate_sender_user_id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "designated_sender_candidate_sender_user_id_candidate_sender_user_id_fk": {
+          "name": "designated_sender_candidate_sender_user_id_candidate_sender_user_id_fk",
+          "tableFrom": "designated_sender",
+          "tableTo": "candidate_sender",
+          "schemaTo": "email",
+          "columnsFrom": [
+            "candidate_sender_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "email.notification": {
+      "name": "notification",
+      "schema": "email",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "ulid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_ulid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "drap": "drap",
+    "auth": "auth",
+    "email": "email"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "drap.active_lab_view": {
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lab_id": {
+          "name": "lab_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lab_name": {
+          "name": "lab_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quota": {
+          "name": "quota",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"created_at\", \"lab_id\", \"lab_name\", \"quota\", \"deleted_at\" from \"drap\".\"lab\" where \"drap\".\"lab\".\"deleted_at\" is null",
+      "name": "active_lab_view",
+      "schema": "drap",
+      "isExisting": false,
+      "materialized": false
+    },
+    "drap.lab_member_view": {
+      "columns": {
+        "student_user_id": {
+          "name": "student_user_id",
+          "type": "ulid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "given_name": {
+          "name": "given_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "family_name": {
+          "name": "family_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"drap\".\"faculty_choice_user\".\"student_user_id\", \"drap\".\"faculty_choice_user\".\"draft_id\", \"drap\".\"faculty_choice_user\".\"lab_id\" as \"draft_lab\", \"drap\".\"user\".\"lab_id\" as \"user_lab\", \"drap\".\"user\".\"email\", \"drap\".\"user\".\"given_name\", \"drap\".\"user\".\"family_name\", \"drap\".\"user\".\"avatar\", \"drap\".\"user\".\"student_number\" from \"drap\".\"user\" right join \"drap\".\"faculty_choice_user\" on \"drap\".\"user\".\"id\" = \"drap\".\"faculty_choice_user\".\"student_user_id\"",
+      "name": "lab_member_view",
+      "schema": "drap",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -110,7 +110,7 @@
     {
       "idx": 15,
       "version": "7",
-      "when": 1753799369310,
+      "when": 1753792995673,
       "tag": "0015_add_registration_closes_at",
       "breakpoints": true
     }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1753792995673,
       "tag": "0015_add_registration_closes_at",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1753848105230,
+      "tag": "0016_backfill-registration-closes-at",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -110,7 +110,7 @@
     {
       "idx": 15,
       "version": "7",
-      "when": 1753792995673,
+      "when": 1753799369310,
       "tag": "0015_add_registration_closes_at",
       "breakpoints": true
     }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1753506632255,
       "tag": "0014_add-lab-member-view",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1753792995673,
+      "tag": "0015_add_registration_closes_at",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1753848105230,
       "tag": "0016_backfill-registration-closes-at",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1753848264626,
+      "tag": "0017_non-null-registration-closes-at",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -614,10 +614,10 @@ export class Database implements Loggable {
     };
   }
 
-  @timed async initDraft(maxRounds: number) {
+  @timed async initDraft(maxRounds: number, registrationClosesAt: Date) {
     return await this.#db
       .insert(schema.draft)
-      .values({ maxRounds })
+      .values({ maxRounds, registrationClosesAt })
       .returning({
         id: schema.draft.id,
         activePeriodStart: sql`lower(${schema.draft.activePeriod})`.mapWith(coerceDate),

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -342,6 +342,7 @@ export class Database implements Loggable {
         id: schema.draft.id,
         currRound: schema.draft.currRound,
         maxRounds: schema.draft.maxRounds,
+        registrationClosesAt: schema.draft.registrationClosesAt,
         activePeriodStart: sql`lower(${schema.draft.activePeriod})`.mapWith(coerceDate).as('_'),
         activePeriodEnd: sql`upper(${schema.draft.activePeriod})`.mapWith(coerceDate),
       })
@@ -354,6 +355,7 @@ export class Database implements Loggable {
       .select({
         currRound: schema.draft.currRound,
         maxRounds: schema.draft.maxRounds,
+        registrationClosesAt: schema.draft.registrationClosesAt,
         activePeriodStart: sql`lower(${schema.draft.activePeriod})`.mapWith(coerceDate),
         activePeriodEnd: sql`upper(${schema.draft.activePeriod})`.mapWith(coerceDate),
       })
@@ -368,6 +370,7 @@ export class Database implements Loggable {
         id: schema.draft.id,
         currRound: schema.draft.currRound,
         maxRounds: schema.draft.maxRounds,
+        registrationClosesAt: schema.draft.registrationClosesAt,
         activePeriodStart: sql`lower(${schema.draft.activePeriod})`.mapWith(coerceDate),
         activePeriodEnd: sql`upper(${schema.draft.activePeriod})`.mapWith(coerceDate),
       })

--- a/src/lib/server/database/schema/app.ts
+++ b/src/lib/server/database/schema/app.ts
@@ -82,6 +82,7 @@ export const draft = app.table(
     id: bigint('id', { mode: 'bigint' }).notNull().generatedAlwaysAsIdentity().primaryKey(),
     currRound: smallint('curr_round').default(0),
     maxRounds: smallint('max_rounds').notNull(),
+    registrationClosesAt: timestamp('registration_closes_at', { mode: 'date', withTimezone: true }),
     activePeriod: tstzrange('active_period')
       .notNull()
       .default(sql`tstzrange(now(), null, '[)')`),

--- a/src/lib/server/database/schema/app.ts
+++ b/src/lib/server/database/schema/app.ts
@@ -82,10 +82,7 @@ export const draft = app.table(
     id: bigint('id', { mode: 'bigint' }).notNull().generatedAlwaysAsIdentity().primaryKey(),
     currRound: smallint('curr_round').default(0),
     maxRounds: smallint('max_rounds').notNull(),
-    registrationClosesAt: timestamp('registration_closes_at', {
-      mode: 'date',
-      withTimezone: true,
-    }).notNull(),
+    registrationClosesAt: timestamp('registration_closes_at', { mode: 'date', withTimezone: true }),
     activePeriod: tstzrange('active_period')
       .notNull()
       .default(sql`tstzrange(now(), null, '[)')`),

--- a/src/lib/server/database/schema/app.ts
+++ b/src/lib/server/database/schema/app.ts
@@ -82,7 +82,7 @@ export const draft = app.table(
     id: bigint('id', { mode: 'bigint' }).notNull().generatedAlwaysAsIdentity().primaryKey(),
     currRound: smallint('curr_round').default(0),
     maxRounds: smallint('max_rounds').notNull(),
-    registrationClosesAt: timestamp('registration_closes_at', { mode: 'date', withTimezone: true }),
+    registrationClosesAt: timestamp('registration_closes_at', { mode: 'date', withTimezone: true }).notNull(),
     activePeriod: tstzrange('active_period')
       .notNull()
       .default(sql`tstzrange(now(), null, '[)')`),

--- a/src/lib/server/database/schema/app.ts
+++ b/src/lib/server/database/schema/app.ts
@@ -82,7 +82,10 @@ export const draft = app.table(
     id: bigint('id', { mode: 'bigint' }).notNull().generatedAlwaysAsIdentity().primaryKey(),
     currRound: smallint('curr_round').default(0),
     maxRounds: smallint('max_rounds').notNull(),
-    registrationClosesAt: timestamp('registration_closes_at', { mode: 'date', withTimezone: true }),
+    registrationClosesAt: timestamp('registration_closes_at', {
+      mode: 'date',
+      withTimezone: true,
+    }).notNull(),
     activePeriod: tstzrange('active_period')
       .notNull()
       .default(sql`tstzrange(now(), null, '[)')`),

--- a/src/lib/server/database/schema/app.ts
+++ b/src/lib/server/database/schema/app.ts
@@ -82,7 +82,10 @@ export const draft = app.table(
     id: bigint('id', { mode: 'bigint' }).notNull().generatedAlwaysAsIdentity().primaryKey(),
     currRound: smallint('curr_round').default(0),
     maxRounds: smallint('max_rounds').notNull(),
-    registrationClosesAt: timestamp('registration_closes_at', { mode: 'date', withTimezone: true }).notNull(),
+    registrationClosesAt: timestamp('registration_closes_at', {
+      mode: 'date',
+      withTimezone: true,
+    }).notNull(),
     activePeriod: tstzrange('active_period')
       .notNull()
       .default(sql`tstzrange(now(), null, '[)')`),

--- a/src/routes/dashboard/(admin)/+layout.server.js
+++ b/src/routes/dashboard/(admin)/+layout.server.js
@@ -1,6 +1,6 @@
 export async function load({ locals: { db } }) {
   return {
     draft: await db.getActiveDraft(),
-    requestedAt: new Date()
+    requestedAt: new Date(),
   };
 }

--- a/src/routes/dashboard/(admin)/+layout.server.js
+++ b/src/routes/dashboard/(admin)/+layout.server.js
@@ -1,3 +1,6 @@
 export async function load({ locals: { db } }) {
-  return { draft: await db.getActiveDraft() };
+  return {
+    draft: await db.getActiveDraft(),
+    requestedAt: new Date()
+  };
 }

--- a/src/routes/dashboard/(admin)/drafts/+layout.svelte
+++ b/src/routes/dashboard/(admin)/drafts/+layout.svelte
@@ -2,7 +2,7 @@
   import { format } from 'date-fns';
 
   const { data, children } = $props();
-  const { draft } = $derived(data);
+  const { draft, requestedAt } = $derived(data);
 </script>
 
 {#if typeof draft !== 'undefined'}
@@ -21,7 +21,7 @@
         <strong>Draft #{draftId}</strong> is currently on Round <strong>{currRound}</strong>
         of <strong>{maxRounds}</strong>. It opened last <strong>{startDate}</strong> at
         <strong>{startTime}</strong>.
-        {#if new Date() < registrationClosesAt}
+        {#if requestedAt < registrationClosesAt}
           Draft registration is currently open and will close on <strong>{closeDate}</strong> at
           <strong>{closeTime}</strong>.
         {:else}

--- a/src/routes/dashboard/(admin)/drafts/+layout.svelte
+++ b/src/routes/dashboard/(admin)/drafts/+layout.svelte
@@ -21,7 +21,7 @@
         <strong>Draft #{draftId}</strong> is currently on Round <strong>{currRound}</strong>
         of <strong>{maxRounds}</strong>. It opened last <strong>{startDate}</strong> at
         <strong>{startTime}</strong>.
-        {#if registrationClosesAt >= new Date()}
+        {#if new Date() < registrationClosesAt}
           Draft registration is currently open and will close on <strong>{closeDate}</strong> at
           <strong>{closeTime}</strong>.
         {:else}

--- a/src/routes/dashboard/(admin)/drafts/+layout.svelte
+++ b/src/routes/dashboard/(admin)/drafts/+layout.svelte
@@ -22,7 +22,8 @@
         of <strong>{maxRounds}</strong>. It opened last <strong>{startDate}</strong> at
         <strong>{startTime}</strong>.
         {#if registrationClosesAt >= new Date()}
-          Draft registration is currently open and will close on <strong>{closeDate}</strong> at <strong>{closeTime}</strong>.
+          Draft registration is currently open and will close on <strong>{closeDate}</strong> at
+          <strong>{closeTime}</strong>.
         {:else}
           Draft registration closed on <strong>{closeDate}</strong> at <strong>{closeTime}</strong>.
         {/if}

--- a/src/routes/dashboard/(admin)/drafts/+layout.svelte
+++ b/src/routes/dashboard/(admin)/drafts/+layout.svelte
@@ -6,9 +6,11 @@
 </script>
 
 {#if typeof draft !== 'undefined'}
-  {@const { id: draftId, currRound, maxRounds, activePeriodStart } = draft}
+  {@const { id: draftId, currRound, maxRounds, registrationClosesAt, activePeriodStart } = draft}
   {@const startDate = format(activePeriodStart, 'PPP')}
   {@const startTime = format(activePeriodStart, 'pp')}
+  {@const closeDate = format(registrationClosesAt, 'PPP')}
+  {@const closeTime = format(registrationClosesAt, 'pp')}
   <div class="card prose dark:prose-invert max-w-none p-4">
     <p>
       {#if currRound === null}
@@ -19,6 +21,11 @@
         <strong>Draft #{draftId}</strong> is currently on Round <strong>{currRound}</strong>
         of <strong>{maxRounds}</strong>. It opened last <strong>{startDate}</strong> at
         <strong>{startTime}</strong>.
+        {#if registrationClosesAt >= new Date()}
+          Draft registration is currently open and will close on <strong>{closeDate}</strong> at <strong>{closeTime}</strong>.
+        {:else}
+          Draft registration closed on <strong>{closeDate}</strong> at <strong>{closeTime}</strong>.
+        {/if}
       {/if}
     </p>
   </div>

--- a/src/routes/dashboard/(admin)/drafts/+page.server.ts
+++ b/src/routes/dashboard/(admin)/drafts/+page.server.ts
@@ -87,9 +87,10 @@ export const actions = {
 
     const data = await request.formData();
     const rounds = parseInt(validateString(data.get('rounds')), 10);
-    db.logger.info({ rounds }, 'initializing draft');
+    const closesAt = new Date(validateString(data.get('closes-at')));
+    db.logger.info({ rounds, closesAt }, 'initializing draft');
 
-    const initDraft = await db.initDraft(rounds);
+    const initDraft = await db.initDraft(rounds, closesAt);
     db.logger.info(initDraft, 'draft initialized');
   },
   async start({ locals: { db, session, dispatch }, request }) {

--- a/src/routes/dashboard/(admin)/drafts/InitForm.svelte
+++ b/src/routes/dashboard/(admin)/drafts/InitForm.svelte
@@ -3,16 +3,18 @@
   import { Icon } from '@steeze-ui/svelte-icon';
   import { assert } from '$lib/assert';
   import { enhance } from '$app/forms';
+  import { format } from 'date-fns';
   import { validateString } from '$lib/forms';
 </script>
 
 <form
   method="post"
   action="/dashboard/drafts/?/init"
-  class="w-full"
+  class="w-full space-y-2"
   use:enhance={({ formData, submitter, cancel }) => {
     const rounds = parseInt(validateString(formData.get('rounds')), 10);
-    if (!confirm(`Are you sure you want to start a new draft with ${rounds} rounds?`)) {
+    const closesAt = new Date(validateString(formData.get('closes-at')));
+    if (!confirm(`Are you sure you want to start a new draft with ${rounds} rounds and with registation that closes at ${format(closesAt, 'PPPpp')}?`)) {
       cancel();
       return;
     }
@@ -25,6 +27,18 @@
     };
   }}
 >
+  <label class="label">
+    <span>Registration Closing Date</span>
+    <div class="input-group grid-cols-[auto_1fr_auto]">
+      <div class="ig-cell preset-tonal"><Icon src={CalendarDays} class="size-6" /></div>
+      <input
+        type="datetime-local"
+        required
+        name="closes-at"
+        class="ig-input px-4 py-2"
+      />
+    </div>
+  </label>
   <label class="label">
     <span>Number of Rounds</span>
     <div class="input-group grid-cols-[auto_1fr_auto]">

--- a/src/routes/dashboard/(admin)/drafts/InitForm.svelte
+++ b/src/routes/dashboard/(admin)/drafts/InitForm.svelte
@@ -14,7 +14,11 @@
   use:enhance={({ formData, submitter, cancel }) => {
     const rounds = parseInt(validateString(formData.get('rounds')), 10);
     const closesAt = new Date(validateString(formData.get('closes-at')));
-    if (!confirm(`Are you sure you want to start a new draft with ${rounds} rounds and with registation that closes at ${format(closesAt, 'PPPpp')}?`)) {
+    if (
+      !confirm(
+        `Are you sure you want to start a new draft with ${rounds} rounds and with registation that closes at ${format(closesAt, 'PPPpp')}?`,
+      )
+    ) {
       cancel();
       return;
     }
@@ -31,12 +35,7 @@
     <span>Registration Closing Date</span>
     <div class="input-group grid-cols-[auto_1fr_auto]">
       <div class="ig-cell preset-tonal"><Icon src={CalendarDays} class="size-6" /></div>
-      <input
-        type="datetime-local"
-        required
-        name="closes-at"
-        class="ig-input px-4 py-2"
-      />
+      <input type="datetime-local" required name="closes-at" class="ig-input px-4 py-2" />
     </div>
   </label>
   <label class="label">

--- a/src/routes/dashboard/(draft)/+layout.server.js
+++ b/src/routes/dashboard/(draft)/+layout.server.js
@@ -7,5 +7,8 @@ export async function load({ locals: { db } }) {
     error(499);
   }
   db.logger.info(draft, 'active draft found');
-  return { draft };
+
+  const requestedAt = new Date();
+
+  return { draft, requestedAt };
 }

--- a/src/routes/dashboard/(draft)/+layout.svelte
+++ b/src/routes/dashboard/(draft)/+layout.svelte
@@ -4,7 +4,7 @@
   const { data, children } = $props();
   const {
     draft: { id, currRound, maxRounds, registrationClosesAt, activePeriodStart },
-    requestedAt
+    requestedAt,
   } = $derived(data);
   const startDate = $derived(format(activePeriodStart, 'PPP'));
   const startTime = $derived(format(activePeriodStart, 'pp'));

--- a/src/routes/dashboard/(draft)/+layout.svelte
+++ b/src/routes/dashboard/(draft)/+layout.svelte
@@ -3,10 +3,12 @@
 
   const { data, children } = $props();
   const {
-    draft: { id, currRound, maxRounds, activePeriodStart },
+    draft: { id, currRound, maxRounds, registrationClosesAt, activePeriodStart },
   } = $derived(data);
   const startDate = $derived(format(activePeriodStart, 'PPP'));
   const startTime = $derived(format(activePeriodStart, 'pp'));
+  const closeDate = $derived(format(registrationClosesAt, 'PPP'));
+  const closeTime = $derived(format(registrationClosesAt, 'pp'));
 </script>
 
 <div class="card prose dark:prose-invert max-w-none p-4">
@@ -19,6 +21,11 @@
       <strong>Draft #{id}</strong> is currently on Round <strong>{currRound}</strong>
       of <strong>{maxRounds}</strong>. It opened last <strong>{startDate}</strong> at
       <strong>{startTime}</strong>.
+      {#if currRound === 0 && registrationClosesAt >= new Date()}
+        Draft registration is currently open and will close on <strong>{closeDate}</strong> at <strong>{closeTime}</strong>.
+      {:else}
+        Draft registration closed on <strong>{closeDate}</strong> at <strong>{closeTime}</strong>.
+      {/if}
     {/if}
   </p>
 </div>

--- a/src/routes/dashboard/(draft)/+layout.svelte
+++ b/src/routes/dashboard/(draft)/+layout.svelte
@@ -22,7 +22,8 @@
       of <strong>{maxRounds}</strong>. It opened last <strong>{startDate}</strong> at
       <strong>{startTime}</strong>.
       {#if currRound === 0 && registrationClosesAt >= new Date()}
-        Draft registration is currently open and will close on <strong>{closeDate}</strong> at <strong>{closeTime}</strong>.
+        Draft registration is currently open and will close on <strong>{closeDate}</strong> at
+        <strong>{closeTime}</strong>.
       {:else}
         Draft registration closed on <strong>{closeDate}</strong> at <strong>{closeTime}</strong>.
       {/if}

--- a/src/routes/dashboard/(draft)/+layout.svelte
+++ b/src/routes/dashboard/(draft)/+layout.svelte
@@ -4,6 +4,7 @@
   const { data, children } = $props();
   const {
     draft: { id, currRound, maxRounds, registrationClosesAt, activePeriodStart },
+    requestedAt
   } = $derived(data);
   const startDate = $derived(format(activePeriodStart, 'PPP'));
   const startTime = $derived(format(activePeriodStart, 'pp'));
@@ -21,7 +22,7 @@
       <strong>Draft #{id}</strong> is currently on Round <strong>{currRound}</strong>
       of <strong>{maxRounds}</strong>. It opened last <strong>{startDate}</strong> at
       <strong>{startTime}</strong>.
-      {#if currRound === 0 && new Date() < registrationClosesAt}
+      {#if currRound === 0 && requestedAt < registrationClosesAt}
         Draft registration is currently open and will close on <strong>{closeDate}</strong> at
         <strong>{closeTime}</strong>.
       {:else}

--- a/src/routes/dashboard/(draft)/+layout.svelte
+++ b/src/routes/dashboard/(draft)/+layout.svelte
@@ -21,7 +21,7 @@
       <strong>Draft #{id}</strong> is currently on Round <strong>{currRound}</strong>
       of <strong>{maxRounds}</strong>. It opened last <strong>{startDate}</strong> at
       <strong>{startTime}</strong>.
-      {#if currRound === 0 && registrationClosesAt >= new Date()}
+      {#if currRound === 0 && new Date() < registrationClosesAt}
         Draft registration is currently open and will close on <strong>{closeDate}</strong> at
         <strong>{closeTime}</strong>.
       {:else}

--- a/src/routes/dashboard/(draft)/ranks/+page.server.js
+++ b/src/routes/dashboard/(draft)/ranks/+page.server.js
@@ -85,13 +85,18 @@ export const actions = {
       return fail(400);
     }
 
-    const maxRounds = await db.getMaxRoundInDraft(draftId);
-    if (typeof maxRounds === 'undefined') {
+    const draft = await db.getDraftById(draftId);
+    if (typeof draft === 'undefined') {
       db.logger.error('cannot find the target draft');
       error(404);
     }
 
+    const { currRound, maxRounds } = draft;
     db.logger.info({ maxRounds }, 'max rounds for target draft determined');
+    if (currRound !== 0) {
+      db.logger.error(draft, 'cannot submit rankings to an ongoing draft')
+      error(403);
+    }
 
     if (labs.length > maxRounds) {
       db.logger.error({ labCount: labs.length }, 'lab rankings exceed max round');

--- a/src/routes/dashboard/(draft)/ranks/+page.server.js
+++ b/src/routes/dashboard/(draft)/ranks/+page.server.js
@@ -94,12 +94,12 @@ export const actions = {
     const { currRound, maxRounds, registrationClosesAt } = draft;
     db.logger.info({ maxRounds }, 'max rounds for target draft determined');
     if (currRound !== 0) {
-      db.logger.error(draft, 'cannot submit rankings to an ongoing draft')
+      db.logger.error(draft, 'cannot submit rankings to an ongoing draft');
       error(403);
     }
 
     if (registrationClosesAt < new Date()) {
-      db.logger.error(draft, 'attempt to submit rankings after registration closed')
+      db.logger.error(draft, 'attempt to submit rankings after registration closed');
       error(403);
     }
 

--- a/src/routes/dashboard/(draft)/ranks/+page.server.js
+++ b/src/routes/dashboard/(draft)/ranks/+page.server.js
@@ -91,10 +91,15 @@ export const actions = {
       error(404);
     }
 
-    const { currRound, maxRounds } = draft;
+    const { currRound, maxRounds, registrationClosesAt } = draft;
     db.logger.info({ maxRounds }, 'max rounds for target draft determined');
     if (currRound !== 0) {
       db.logger.error(draft, 'cannot submit rankings to an ongoing draft')
+      error(403);
+    }
+
+    if (registrationClosesAt < new Date()) {
+      db.logger.error(draft, 'attempt to submit rankings after registration closed')
       error(403);
     }
 

--- a/src/routes/dashboard/(draft)/ranks/+page.server.js
+++ b/src/routes/dashboard/(draft)/ranks/+page.server.js
@@ -42,7 +42,9 @@ export async function load({ locals: { db, session }, parent }) {
 
   db.logger.trace({ availableLabCount: availableLabs.length }, 'available labs fetched');
 
-  return { draft, availableLabs, rankings };
+  const requestedAt = new Date();
+
+  return { draft, availableLabs, rankings, requestedAt };
 }
 
 export const actions = {

--- a/src/routes/dashboard/(draft)/ranks/+page.server.js
+++ b/src/routes/dashboard/(draft)/ranks/+page.server.js
@@ -72,11 +72,11 @@ export const actions = {
     }
 
     const data = await request.formData();
-    const draft = BigInt(validateString(data.get('draft')));
+    const draftId = BigInt(validateString(data.get('draft')));
     const labs = data.getAll('labs').map(validateString);
     const remarks = data.getAll('remarks').map(validateMaybeEmptyString);
     db.logger.info(
-      { draft, labCount: labs.length, remarksCount: remarks.length },
+      { draftId, labCount: labs.length, remarksCount: remarks.length },
       'lab rankings submitted',
     );
 
@@ -85,7 +85,7 @@ export const actions = {
       return fail(400);
     }
 
-    const maxRounds = await db.getMaxRoundInDraft(draft);
+    const maxRounds = await db.getMaxRoundInDraft(draftId);
     if (typeof maxRounds === 'undefined') {
       db.logger.error('cannot find the target draft');
       error(404);
@@ -98,7 +98,7 @@ export const actions = {
       error(400);
     }
 
-    await db.insertStudentRanking(draft, user.id, labs, remarks);
+    await db.insertStudentRanking(draftId, user.id, labs, remarks);
     db.logger.info('lab rankings inserted');
     // TODO: Add proper logging/handling of insert errors.
   },

--- a/src/routes/dashboard/(draft)/ranks/+page.svelte
+++ b/src/routes/dashboard/(draft)/ranks/+page.svelte
@@ -20,18 +20,7 @@
 {:else if currRound > 0}
   <WarningAlert>A draft is currently ongoing. You may no longer register.</WarningAlert>
   <Progress max={maxRounds} value={currRound} meterBg="bg-primary-700-300" />
-{:else if typeof rankings === 'undefined'}
-  {#if requestedAt < registrationClosesAt}
-    <SubmitRankings {draftId} {maxRounds} {availableLabs} />
-  {:else}
-    {@const closeDate = format(registrationClosesAt, 'PPP')}
-    {@const closeTime = format(registrationClosesAt, 'pp')}
-    <WarningAlert
-      >Registration for the current draft closed on <strong>{closeDate}</strong> at
-      <strong>{closeTime}</strong>. You may no longer register.</WarningAlert
-    >
-  {/if}
-{:else}
+{:else if typeof rankings !== 'undefined'}
   {@const { createdAt, labRemarks } = rankings}
   {@const creationDate = format(createdAt, 'PPP')}
   {@const creationTime = format(createdAt, 'pp')}
@@ -63,4 +52,13 @@
       <p>You have selected none of the labs. You will thus skip ahead to the lottery phase.</p>
     {/if}
   </div>
+{:else if requestedAt < registrationClosesAt}
+  <SubmitRankings {draftId} {maxRounds} {availableLabs} />
+{:else}
+  {@const closeDate = format(registrationClosesAt, 'PPP')}
+  {@const closeTime = format(registrationClosesAt, 'pp')}
+  <WarningAlert
+    >Registration for the current draft closed on <strong>{closeDate}</strong> at
+    <strong>{closeTime}</strong>. You may no longer register.</WarningAlert
+  >
 {/if}

--- a/src/routes/dashboard/(draft)/ranks/+page.svelte
+++ b/src/routes/dashboard/(draft)/ranks/+page.svelte
@@ -9,6 +9,7 @@
     draft: { id: draftId, currRound, maxRounds, registrationClosesAt },
     availableLabs,
     rankings,
+    requestedAt,
   } = $derived(data);
 </script>
 
@@ -20,7 +21,7 @@
   <WarningAlert>A draft is currently ongoing. You may no longer register.</WarningAlert>
   <Progress max={maxRounds} value={currRound} meterBg="bg-primary-700-300" />
 {:else if typeof rankings === 'undefined'}
-  {#if new Date() < registrationClosesAt}
+  {#if requestedAt < registrationClosesAt}
     <SubmitRankings {draftId} {maxRounds} {availableLabs} />
   {:else}
     {@const closeDate = format(registrationClosesAt, 'PPP')}

--- a/src/routes/dashboard/(draft)/ranks/+page.svelte
+++ b/src/routes/dashboard/(draft)/ranks/+page.svelte
@@ -12,46 +12,47 @@
   } = $derived(data);
 </script>
 
-{#if typeof rankings === 'undefined'}
-  <SubmitRankings {draftId} {maxRounds} {availableLabs} />
-{:else}
-  {@const { createdAt, labRemarks } = rankings}
-  {@const creationDate = format(createdAt, 'PPP')}
-  {@const creationTime = format(createdAt, 'pp')}
-  {#if currRound === null}
-    <WarningAlert
-      >A lottery is currently ongoing. You may join again soon in the next draft.</WarningAlert
-    >
-  {:else}
-    <WarningAlert>A draft is currently ongoing. You may no longer register.</WarningAlert>
-    <Progress max={maxRounds} value={currRound} meterBg="bg-primary-700-300" />
-  {/if}
-  <div
-    class="card preset-tonal-secondary border-secondary-500 prose dark:prose-invert max-w-none border p-4"
+{#if currRound === null}
+  <WarningAlert
+    >A lottery is currently ongoing. You may join again soon in the next draft.</WarningAlert
   >
-    <p>
-      You have already submitted your lab preferences for this draft last <strong
-        >{creationDate}</strong
-      >
-      at
-      <strong>{creationTime}</strong>.
-    </p>
-    {#if labRemarks.length > 0}
-      <ol>
-        {#each labRemarks as { lab, remark } (lab)}
-          <li>
-            {lab}
-            {#if remark.length > 0}
-              <p class="text-sm">
-                <strong>Remarks:</strong>
-                {remark}
-              </p>
-            {/if}
-          </li>
-        {/each}
-      </ol>
-    {:else}
-      <p>You have selected none of the labs. You will thus skip ahead to the lottery phase.</p>
-    {/if}
-  </div>
+{:else if currRound > 0}
+  <WarningAlert>A draft is currently ongoing. You may no longer register.</WarningAlert>
+  <Progress max={maxRounds} value={currRound} meterBg="bg-primary-700-300" />
+{:else}
+  {#if typeof rankings === 'undefined'}
+    <SubmitRankings {draftId} {maxRounds} {availableLabs} />
+  {:else if typeof rankings !== 'undefined'}
+    {@const { createdAt, labRemarks } = rankings}
+    {@const creationDate = format(createdAt, 'PPP')}
+    {@const creationTime = format(createdAt, 'pp')}
+    <div
+      class="card preset-tonal-secondary border-secondary-500 prose dark:prose-invert max-w-none border p-4"
+    >
+      <p>
+        You have already submitted your lab preferences for this draft last <strong
+          >{creationDate}</strong
+        >
+        at
+        <strong>{creationTime}</strong>.
+      </p>
+      {#if labRemarks.length > 0}
+        <ol>
+          {#each labRemarks as { lab, remark } (lab)}
+            <li>
+              {lab}
+              {#if remark.length > 0}
+                <p class="text-sm">
+                  <strong>Remarks:</strong>
+                  {remark}
+                </p>
+              {/if}
+            </li>
+          {/each}
+        </ol>
+      {:else}
+        <p>You have selected none of the labs. You will thus skip ahead to the lottery phase.</p>
+      {/if}
+    </div>
+  {/if}
 {/if}

--- a/src/routes/dashboard/(draft)/ranks/+page.svelte
+++ b/src/routes/dashboard/(draft)/ranks/+page.svelte
@@ -20,7 +20,7 @@
   <WarningAlert>A draft is currently ongoing. You may no longer register.</WarningAlert>
   <Progress max={maxRounds} value={currRound} meterBg="bg-primary-700-300" />
 {:else if typeof rankings === 'undefined'}
-  {#if registrationClosesAt >= new Date()}
+  {#if new Date() < registrationClosesAt}
     <SubmitRankings {draftId} {maxRounds} {availableLabs} />
   {:else}
     {@const closeDate = format(registrationClosesAt, 'PPP')}

--- a/src/routes/dashboard/(draft)/ranks/+page.svelte
+++ b/src/routes/dashboard/(draft)/ranks/+page.svelte
@@ -19,46 +19,47 @@
 {:else if currRound > 0}
   <WarningAlert>A draft is currently ongoing. You may no longer register.</WarningAlert>
   <Progress max={maxRounds} value={currRound} meterBg="bg-primary-700-300" />
-{:else}
-  {#if typeof rankings === 'undefined'}
-    {#if registrationClosesAt >= new Date()}
-      <SubmitRankings {draftId} {maxRounds} {availableLabs} />
-    {:else}
-      {@const closeDate = format(registrationClosesAt, 'PPP')}
-      {@const closeTime = format(registrationClosesAt, 'pp')}
-      <WarningAlert>Registration for the current draft closed on <strong>{closeDate}</strong> at <strong>{closeTime}</strong>. You may no longer register.</WarningAlert>
-    {/if}
+{:else if typeof rankings === 'undefined'}
+  {#if registrationClosesAt >= new Date()}
+    <SubmitRankings {draftId} {maxRounds} {availableLabs} />
   {:else}
-    {@const { createdAt, labRemarks } = rankings}
-    {@const creationDate = format(createdAt, 'PPP')}
-    {@const creationTime = format(createdAt, 'pp')}
-    <div
-      class="card preset-tonal-secondary border-secondary-500 prose dark:prose-invert max-w-none border p-4"
+    {@const closeDate = format(registrationClosesAt, 'PPP')}
+    {@const closeTime = format(registrationClosesAt, 'pp')}
+    <WarningAlert
+      >Registration for the current draft closed on <strong>{closeDate}</strong> at
+      <strong>{closeTime}</strong>. You may no longer register.</WarningAlert
     >
-      <p>
-        You have already submitted your lab preferences for this draft last <strong
-          >{creationDate}</strong
-        >
-        at
-        <strong>{creationTime}</strong>.
-      </p>
-      {#if labRemarks.length > 0}
-        <ol>
-          {#each labRemarks as { lab, remark } (lab)}
-            <li>
-              {lab}
-              {#if remark.length > 0}
-                <p class="text-sm">
-                  <strong>Remarks:</strong>
-                  {remark}
-                </p>
-              {/if}
-            </li>
-          {/each}
-        </ol>
-      {:else}
-        <p>You have selected none of the labs. You will thus skip ahead to the lottery phase.</p>
-      {/if}
-    </div>
   {/if}
+{:else}
+  {@const { createdAt, labRemarks } = rankings}
+  {@const creationDate = format(createdAt, 'PPP')}
+  {@const creationTime = format(createdAt, 'pp')}
+  <div
+    class="card preset-tonal-secondary border-secondary-500 prose dark:prose-invert max-w-none border p-4"
+  >
+    <p>
+      You have already submitted your lab preferences for this draft last <strong
+        >{creationDate}</strong
+      >
+      at
+      <strong>{creationTime}</strong>.
+    </p>
+    {#if labRemarks.length > 0}
+      <ol>
+        {#each labRemarks as { lab, remark } (lab)}
+          <li>
+            {lab}
+            {#if remark.length > 0}
+              <p class="text-sm">
+                <strong>Remarks:</strong>
+                {remark}
+              </p>
+            {/if}
+          </li>
+        {/each}
+      </ol>
+    {:else}
+      <p>You have selected none of the labs. You will thus skip ahead to the lottery phase.</p>
+    {/if}
+  </div>
 {/if}

--- a/src/routes/dashboard/(draft)/ranks/+page.svelte
+++ b/src/routes/dashboard/(draft)/ranks/+page.svelte
@@ -6,7 +6,7 @@
 
   const { data } = $props();
   const {
-    draft: { id: draftId, currRound, maxRounds },
+    draft: { id: draftId, currRound, maxRounds, registrationClosesAt },
     availableLabs,
     rankings,
   } = $derived(data);
@@ -21,8 +21,14 @@
   <Progress max={maxRounds} value={currRound} meterBg="bg-primary-700-300" />
 {:else}
   {#if typeof rankings === 'undefined'}
-    <SubmitRankings {draftId} {maxRounds} {availableLabs} />
-  {:else if typeof rankings !== 'undefined'}
+    {#if registrationClosesAt >= new Date()}
+      <SubmitRankings {draftId} {maxRounds} {availableLabs} />
+    {:else}
+      {@const closeDate = format(registrationClosesAt, 'PPP')}
+      {@const closeTime = format(registrationClosesAt, 'pp')}
+      <WarningAlert>Registration for the current draft closed on <strong>{closeDate}</strong> at <strong>{closeTime}</strong>. You may no longer register.</WarningAlert>
+    {/if}
+  {:else}
     {@const { createdAt, labRemarks } = rankings}
     {@const creationDate = format(createdAt, 'PPP')}
     {@const creationTime = format(createdAt, 'pp')}


### PR DESCRIPTION
This PR closes #61, although we will need to create a separate issue regarding the interface for "deleting registered students not qualified for the draft." This was primarily achieved by adding a `registration_closes_at` column with type `timestamptz`, which indicates the date and time when draft registration will be closed. This is compared with the current date and time to determine whether users should be allowed to submit their lab picks or not (which completes their "registration"). An input has also been added to the draft initialization page to allow admins to set the value of `registration_closes_at` for a draft.

Additionally, this PR addresses a large oversight where students were still able to register and submit their lab rankings in the middle of an ongoing draft/lottery round. 

Note that the `registration_closes_at` constraints enforce that it cannot be `NULL`. However, given that there is existing data in our database, this may become an issue when running the migrations. If necessary, the migrations can be adjusted to instead allow `NULL` or set it to some default value (e.g. `now()`).