### PR TITLE
fix: prevent student draftees from seeing draftees of other rounds

### DIFF
--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -324,7 +324,7 @@ export class Database implements Loggable {
     let members = [];
 
     // if no draft id is specified
-    if (typeof draftId === 'undefined') 
+    if (typeof draftId === 'undefined')
       members = await this.#db
         .select({
           draftId: schema.labMemberView.draftId,
@@ -336,9 +336,8 @@ export class Database implements Loggable {
         .from(schema.labMemberView)
         .where(eq(schema.labMemberView.draftLab, labId))
         .orderBy(asc(schema.labMemberView.draftId), asc(schema.labMemberView.familyName));
-
     // if a draft id is specified
-    else 
+    else
       members = await this.#db
         .select({
           draftId: schema.labMemberView.draftId,
@@ -348,7 +347,9 @@ export class Database implements Loggable {
           avatarUrl: schema.labMemberView.avatarUrl,
         })
         .from(schema.labMemberView)
-        .where(and(eq(schema.labMemberView.draftLab, labId), eq(schema.labMemberView.draftId, draftId)))
+        .where(
+          and(eq(schema.labMemberView.draftLab, labId), eq(schema.labMemberView.draftId, draftId)),
+        )
         .orderBy(asc(schema.labMemberView.draftId), asc(schema.labMemberView.familyName));
 
     return { lab: labInfo?.name, heads, members, faculty };
@@ -360,13 +361,13 @@ export class Database implements Loggable {
    * @param labId The id of the lab they were assigned for
    */
   @timed async getUserLabAssignmentDraftId(userId: string, labId: string) {
-    const [first, ..._rest] =  await this.#db
+    const [first, ..._rest] = await this.#db
       .select({
-        draftId: schema.labMemberView.draftId
+        draftId: schema.labMemberView.draftId,
       })
       .from(schema.labMemberView)
       .where(and(eq(schema.labMemberView.userId, userId), eq(schema.labMemberView.draftLab, labId)))
-      .orderBy(desc(schema.labMemberView.draftId))
+      .orderBy(desc(schema.labMemberView.draftId));
     return first;
   }
 

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -355,16 +355,17 @@ export class Database implements Loggable {
   }
 
   /**
-   * Get the latest draft id that a user participated in
+   * Get the latest draft id that a user participated in to be assigned to a certain lab
    * @param userId The id of the user whose draft id is to be identified
+   * @param labId The id of the lab they were assigned for
    */
-  @timed async getUserLatestDraftId(userId: string) {
+  @timed async getUserLabAssignmentDraftId(userId: string, labId: string) {
     const [first, ..._rest] =  await this.#db
       .select({
         draftId: schema.labMemberView.draftId
       })
       .from(schema.labMemberView)
-      .where(eq(schema.labMemberView.userId, userId))
+      .where(and(eq(schema.labMemberView.userId, userId), eq(schema.labMemberView.draftLab, labId)))
       .orderBy(desc(schema.labMemberView.draftId))
     return first;
   }

--- a/src/routes/dashboard/lab/+page.server.js
+++ b/src/routes/dashboard/lab/+page.server.js
@@ -21,20 +21,24 @@ export async function load({ locals: { db, session } }) {
   let info;
 
   if (session.user.isAdmin) {
-    info = await db.getLabMembers(session.user.labId)
+    info = await db.getLabMembers(session.user.labId);
   } else {
-    const userLatestDraft = await db.getUserLabAssignmentDraftId(session.user.id, session.user.labId);
+    const userLatestDraft = await db.getUserLabAssignmentDraftId(
+      session.user.id,
+      session.user.labId,
+    );
     if (typeof userLatestDraft === 'undefined') {
       db.logger.error(
         {
           userId: session.user.id,
-          labId: session.user.labId
-        }, 
-        'attempt to get draft id for student-user\'s assignment to this lab returned undefined');
+          labId: session.user.labId,
+        },
+        "attempt to get draft id for student-user's assignment to this lab returned undefined",
+      );
       error(400);
-    } 
+    }
     const { draftId: userLatestDraftId } = userLatestDraft;
-    info = await db.getLabMembers(session.user.labId, userLatestDraftId)
+    info = await db.getLabMembers(session.user.labId, userLatestDraftId);
   }
 
   await db.getLabMembers(session.user.labId);


### PR DESCRIPTION
This PR ensures that student-users are unable to see the results of drafts other than their own (determined as the latest draft id with a faculty choice corresponding to their user id and the lab id that they were assigned to). Lab admins are still able to see all current and previous members of their labs; however.

- **feat: allow lab member getting logic to limit results returned based on draft id**
- **feat: implement getter for latest draft id of a user**
- **feat: add lab id to double-check retrieved draft id**
- **feat: integrate new lab member retrieval logic to server load**
- **chore: run formatter**
