### PR TITLE
fix(dev): forward `OTEL_*` env vars into `process.env` via Vite plugin

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,23 @@
+import { cwd, env } from 'node:process';
+
 import tailwind from '@tailwindcss/vite';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 
 export default defineConfig({
-  plugins: [tailwind(), sveltekit()],
+  plugins: [
+    {
+      name: 'open-telemetry-env-loader',
+      config(_, { mode }) {
+        // Loads OpenTelemetry environment variables into `pnpm dev` and `pnpm preview`.
+        // Existing environment variables are not overridden.
+        const otel = loadEnv(mode, cwd(), 'OTEL_');
+        for (const [key, value] of Object.entries(otel)) env[key] ??= value;
+      },
+    },
+    tailwind(),
+    sveltekit(),
+  ],
   build: { assetsInlineLimit: 0 },
   server: { allowedHosts: ['host.docker.internal'] },
 });


### PR DESCRIPTION
Vite does not inject `.env` file variables into `process.env` for server-side code — only into `import.meta.env` (filtered by `VITE_` prefix) and SvelteKit's `$env` modules. This means the OpenTelemetry Node SDK cannot auto-configure from `OTEL_*` variables in `.env` files during `pnpm dev`, requiring the manual workaround of `set -a && source .env` before starting the dev server.

This PR adds an inline Vite plugin that uses `loadEnv` with the `OTEL_` prefix in the `config` hook to forward those variables into `process.env` before `instrumentation.server.js` runs. Existing environment variables are preserved via `??=`, consistent with Vite's own precedence convention (shell/system env > `.env` files).

## Implementation Notes

The plugin is placed first in the `plugins` array so it runs before other plugins. It uses Vite's own `loadEnv` API with `'OTEL_'` as the prefix filter, which respects the standard `.env` file priority order (`.env` < `.env.local` < `.env.[mode]` < `.env.[mode].local`). The `??=` assignment ensures that real environment variables from the deployment or shell always take precedence over `.env` file values, matching Vite's established conventions.

## Test Cases

- [x] `pnpm dev` picks up `OTEL_*` variables from `.env` without needing `set -a && source .env`
- [x] Shell-provided `OTEL_*` variables are not overridden by `.env` file values
- [x] Non-`OTEL_*` variables in `.env` are not leaked into `process.env`
- [x] `pnpm build` completes without errors
