### PR TITLE
docs: add notes for database initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ pnpm db:migrate
 pnpm db:studio
 ```
 
+> [!IMPORTANT]
+> You must run `pnpm db:migrate` on a fresh database in order to initialize the tables.
+
 ### Linting the Codebase
 
 ```bash


### PR DESCRIPTION
This PR adds documentation on using `pnpm db:migrate` to initialize a fresh database.