### PR TITLE
feat(app): implement batched assignment results for draft conclusion

### DIFF
--- a/src/lib/features/dev-tools/email-dispatcher/form.svelte
+++ b/src/lib/features/dev-tools/email-dispatcher/form.svelte
@@ -15,6 +15,8 @@
   import { Input } from '$lib/components/ui/input';
   import { Label } from '$lib/components/ui/label';
 
+  import LotteryAssignmentsInput from './lottery-assignments-input.svelte';
+
   const { onSuccess }: Props = $props();
 
   let selectedEvent = $state('draft/round.started');
@@ -150,6 +152,7 @@
           placeholder="example@up.edu.ph"
         />
       </div>
+      <LotteryAssignmentsInput />
     {:else if selectedEvent === 'draft/user.assigned'}
       <div class="space-y-2">
         <Label for="labId">Lab ID</Label>

--- a/src/lib/features/dev-tools/email-dispatcher/lottery-assignments-input.svelte
+++ b/src/lib/features/dev-tools/email-dispatcher/lottery-assignments-input.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import PlusIcon from '@lucide/svelte/icons/plus';
+  import Trash2Icon from '@lucide/svelte/icons/trash-2';
+
+  import { assert } from '$lib/assert';
+  import { Button } from '$lib/components/ui/button';
+  import { Input } from '$lib/components/ui/input';
+  import { Label } from '$lib/components/ui/label';
+
+  interface AssignmentRow {
+    id: string;
+    labId: string;
+    studentEmail: string;
+  }
+
+  interface Props {
+    name?: string;
+  }
+
+  const { name = 'lotteryAssignments' }: Props = $props();
+  const rows = $state<AssignmentRow[]>([]);
+
+  function addRow() {
+    rows.push({ id: crypto.randomUUID(), labId: '', studentEmail: '' });
+  }
+
+  function removeRow(index: number) {
+    const [row, ...rest] = rows.splice(index, 1);
+    assert(rest.length === 0);
+    return row;
+  }
+</script>
+
+<div class="space-y-2">
+  <Label>Lottery Assignments</Label>
+  <div class="space-y-2">
+    {#each rows as row, index (row.id)}
+      <div class="flex items-end gap-2">
+        <Input
+          type="text"
+          name="{name}.{index}.labId"
+          bind:value={row.labId}
+          placeholder="ndsl"
+          required
+        />
+        <Input
+          type="email"
+          name="{name}.{index}.studentEmail"
+          bind:value={row.studentEmail}
+          placeholder="student@up.edu.ph"
+          required
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onclick={({ currentTarget }) => {
+            const id = currentTarget.dataset.index;
+            if (typeof id !== 'undefined') removeRow(Number.parseInt(id, 10));
+          }}
+          aria-label="Remove Lottery Assignment"
+          data-index={index}
+        >
+          <Trash2Icon class="size-4" />
+        </Button>
+      </div>
+    {/each}
+    <Button
+      type="button"
+      variant="outline"
+      class="text-muted-foreground w-full justify-start border-2 border-dashed"
+      onclick={addRow}
+    >
+      <PlusIcon class="size-4" />
+      <span>Add Lottery Assignment</span>
+    </Button>
+  </div>
+</div>

--- a/src/lib/features/drafts/timeline/quota-snapshot-form.svelte
+++ b/src/lib/features/drafts/timeline/quota-snapshot-form.svelte
@@ -31,7 +31,7 @@
   );
 </script>
 
-<Card.Root id={`draft-quota-editor-${mode}`} class="border-0">
+<Card.Root id="draft-quota-editor-{mode}" class="border-0">
   <Card.Header>
     <Card.Title>{title}</Card.Title>
     <Card.Description>{description}</Card.Description>

--- a/src/lib/features/drafts/timeline/summary/index.svelte
+++ b/src/lib/features/drafts/timeline/summary/index.svelte
@@ -156,11 +156,11 @@
                   <p class="text-muted-foreground px-1 text-sm">
                     Intervention assignment to <strong>{labName}</strong> on
                     {#if assignedAt !== null}
-                      <time id={`intervention-date-${id}`} datetime={assignedAt.toISOString()}>
+                      <time id="intervention-date-{id}" datetime={assignedAt.toISOString()}>
                         {format(assignedAt, 'PPP p')}
                       </time>
                     {:else}
-                      <span id={`intervention-date-${id}`}>Unknown date</span>
+                      <span id="intervention-date-{id}">Unknown date</span>
                     {/if}
                     .
                   </p>

--- a/src/lib/server/inngest/functions/send-email/draft-concluded.svelte
+++ b/src/lib/server/inngest/functions/send-email/draft-concluded.svelte
@@ -5,11 +5,44 @@
 
   import EmailLayout from './email-layout.svelte';
 
-  interface Props {
-    draftId: number;
+  interface LotteryAssignment {
+    labId: string;
+    labName: string;
+    studentName: string;
+    studentEmail: string;
   }
 
-  const { draftId }: Props = $props();
+  interface GroupedLotteryAssignment {
+    labId: string;
+    labName: string;
+    students: Pick<LotteryAssignment, 'studentName' | 'studentEmail'>[];
+  }
+
+  interface Props {
+    draftId: number;
+    lotteryAssignments: LotteryAssignment[];
+  }
+
+  const { draftId, lotteryAssignments }: Props = $props();
+  const groupedLotteryAssignments = $derived.by(() => {
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- local grouping container in derived computation
+    const grouped = new Map<string, GroupedLotteryAssignment>();
+    for (const { labId, labName, studentName, studentEmail } of lotteryAssignments) {
+      const existing = grouped.get(labId);
+      if (typeof existing === 'undefined') {
+        grouped.set(labId, {
+          labId,
+          labName,
+          students: [{ studentName, studentEmail }],
+        });
+        continue;
+      }
+      existing.students.push({ studentName, studentEmail });
+    }
+    return Array.from(grouped.values()).sort((left, right) =>
+      left.labId.localeCompare(right.labId),
+    );
+  });
 </script>
 
 <EmailLayout preview="Draft #{draftId} has concluded - View final assignments">
@@ -19,6 +52,25 @@
       Draft <strong class="text-foreground">#{draftId}</strong> has just concluded. All registered students
       have been assigned to their respective research labs.
     </Text>
+    {#if groupedLotteryAssignments.length > 0}
+      <Section class="bg-card text-card-foreground my-6 rounded-lg">
+        <Section class="mx-auto max-w-md py-4">
+          <Heading class="text-foreground text-lg font-semibold" as="h2">
+            Finalized Lottery Results
+          </Heading>
+          {#each groupedLotteryAssignments as group (group.labId)}
+            <Section class="border-muted my-3 rounded-md border px-3 py-2">
+              <Text class="mb-2 text-sm font-semibold">{group.labName}</Text>
+              {#each group.students as student (`${group.labId}:${student.studentEmail}`)}
+                <Text class="my-0 text-sm leading-relaxed">
+                  <a href="mailto:{student.studentEmail}">{student.studentName}</a>
+                </Text>
+              {/each}
+            </Section>
+          {/each}
+        </Section>
+      </Section>
+    {/if}
     <Section class="bg-secondary/30 text-secondary-foreground my-6 rounded-lg">
       <Section class="mx-auto max-w-md">
         <Text class="text-sm">See the new roster of researchers through the lab module.</Text>

--- a/src/lib/server/inngest/functions/send-email/index.ts
+++ b/src/lib/server/inngest/functions/send-email/index.ts
@@ -110,9 +110,10 @@ export const sendEmail = inngest.createFunction(
                   recipient = event.data.recipientEmail;
                   subject = `[DRAP] Draft #${event.data.draftId} Concluded`;
                   html = await renderer.render(DraftConcluded, {
-                    props: { draftId: event.data.draftId } satisfies ComponentProps<
-                      typeof DraftConcluded
-                    >,
+                    props: {
+                      draftId: event.data.draftId,
+                      lotteryAssignments: event.data.lotteryAssignments,
+                    } satisfies ComponentProps<typeof DraftConcluded>,
                   });
                   break;
                 case 'draft/user.assigned':

--- a/src/lib/server/inngest/schema.ts
+++ b/src/lib/server/inngest/schema.ts
@@ -32,6 +32,14 @@ export const DraftConcludedEvent = v.object({
   draftId: v.number(),
   recipientEmail: v.string(),
   recipientName: v.string(),
+  lotteryAssignments: v.array(
+    v.object({
+      labId: v.string(),
+      labName: v.string(),
+      studentName: v.string(),
+      studentEmail: v.string(),
+    }),
+  ),
 });
 export type DraftConcludedEvent = v.InferOutput<typeof DraftConcludedEvent>;
 

--- a/src/routes/dashboard/+page.server.js
+++ b/src/routes/dashboard/+page.server.js
@@ -60,6 +60,11 @@ const DevDummyFormData = v.object({
   familyName: v.pipe(v.string(), v.minLength(1)),
 });
 
+const LotteryAssignmentFormData = v.object({
+  labId: v.pipe(v.string(), v.minLength(1)),
+  studentEmail: v.pipe(v.string(), v.email()),
+});
+
 const SendEmailFormData = v.variant('event', [
   v.object({
     event: v.literal('draft/round.started'),
@@ -85,6 +90,7 @@ const SendEmailFormData = v.variant('event', [
     event: v.literal('draft/draft.concluded'),
     draftId: v.number(),
     recipientEmail: v.string(),
+    lotteryAssignments: v.optional(v.array(LotteryAssignmentFormData), []),
   }),
   v.object({
     event: v.literal('draft/user.assigned'),
@@ -200,7 +206,10 @@ export const actions = {
             }
 
             const data = await request.formData();
-            const decoded = decode(data, { numbers: ['draftId', 'round'] });
+            const decoded = decode(data, {
+              arrays: ['lotteryAssignments'],
+              numbers: ['draftId', 'round'],
+            });
             const parsed = v.parse(SendEmailFormData, decoded);
 
             logger.info('dispatching email event');
@@ -254,16 +263,30 @@ export const actions = {
                 break;
               }
               case 'draft/draft.concluded': {
-                const { givenName, familyName } = await getUserNameByEmail(
-                  db,
-                  parsed.recipientEmail,
-                );
+                const [{ givenName, familyName }, lotteryAssignments] = await Promise.all([
+                  getUserNameByEmail(db, parsed.recipientEmail),
+                  Promise.all(
+                    parsed.lotteryAssignments.map(async ({ labId, studentEmail }) => {
+                      const [lab, student] = await Promise.all([
+                        getLabById(db, labId),
+                        getUserNameByEmail(db, studentEmail),
+                      ]);
+                      return {
+                        labId,
+                        labName: lab.name,
+                        studentName: `${student.givenName} ${student.familyName}`,
+                        studentEmail,
+                      };
+                    }),
+                  ),
+                ]);
                 await inngest.send({
                   name: parsed.event,
                   data: {
                     draftId: parsed.draftId,
                     recipientEmail: parsed.recipientEmail,
                     recipientName: `${givenName} ${familyName}`,
+                    lotteryAssignments,
                   },
                 });
                 break;


### PR DESCRIPTION
This pull request closes #137 by updating draft conclusion notifications to include batched lottery assignment results in the `draft/draft.concluded` flow. During draft conclusion, the server now resolves all lottery-assigned students with lab metadata and sends a single concluded event per recipient with the full assignment batch attached.

The draft-concluded email renderer now accepts `lotteryAssignments`, groups entries by lab, and renders a dedicated "Finalized Lottery Results" section listing assigned students per lab. The dev email dispatcher was also extended with a lottery-assignment form input so admins can manually compose and verify this payload before dispatch.

## Implementation Notes

- Extended the `draft/draft.concluded` Inngest schema payload with `lotteryAssignments` and updated the email sender to pass this prop into the Svelte email component.
- Replaced per-assignment notification dispatch in the draft conclusion action with batched assignment materialization, then attached the full batch to each concluded email event.
- Updated dashboard dev tooling to decode `lotteryAssignments[]` form data, resolve `labName` and `studentName`, and dispatch a shape-compatible concluded event for email preview/testing.

## Breaking Changes

- Event contract update: `draft/draft.concluded` now includes `lotteryAssignments` in the payload. In-repo senders were updated accordingly, and dev tooling defaults to an empty list when omitted.

## Test Cases

- [x] Conclude a draft with lottery assignments and verify recipients receive one draft-concluded email that includes grouped lottery results.
- [x] Conclude a draft with no lottery assignments and verify the draft-concluded email still sends and omits the `lottery-results` section.
- [x] Use the dashboard dev email dispatcher for `draft/draft.concluded` and verify lottery assignments are resolved and rendered correctly.
  - [x] Multiple labs are grouped into separate sections in the rendered email.
  - [x] Multiple students in one lab are listed under the same lab section.
  - [x] Empty lottery assignments are accepted and produce a valid concluded email payload.
