### PR TITLE
feat(app): add post-startup migration service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.13.0-alpine3.23 AS build
+FROM node:24.13.0-alpine3.23 AS base
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
@@ -18,6 +18,13 @@ RUN --mount=type=bind,source=package.json,target=package.json \
     --mount=type=bind,source=pnpm-workspace.yaml,target=pnpm-workspace.yaml \
     --mount=type=cache,id=pnpm,target=$PNPM_HOME/store \
     pnpm install --offline
+
+FROM base AS migrate
+
+# Migration files are provided as bind mounts.
+ENTRYPOINT ["pnpm", "db:migrate"]
+
+FROM base AS build
 
 # Build the app and prune dev dependencies. Bind-mounted source files
 # are not baked into the layer — only build/ and node_modules/ persist.

--- a/compose.app.yaml
+++ b/compose.app.yaml
@@ -14,9 +14,48 @@ services:
     networks:
       - durability
 
+  migrate:
+    pull_policy: build
+    build:
+      context: .
+      target: migrate
+    environment:
+      POSTGRES_URL: postgresql://postgres:${POSTGRES_PASSWORD:?required}@postgres:5432/postgres
+    volumes:
+      - type: bind
+        source: ./package.json
+        target: /app/package.json
+        read_only: true
+      - type: bind
+        source: ./drizzle.config.js
+        target: /app/drizzle.config.js
+        read_only: true
+      - type: bind
+        source: ./drizzle
+        target: /app/drizzle
+        read_only: true
+      - type: bind
+        source: ./src/lib/server/database/schema
+        target: /app/src/lib/server/database/schema
+        read_only: true
+    networks:
+      - database
+    depends_on:
+      # Wait for the app to start before running migrations. This ensures
+      # the app is not broken before irreversibly applying migrations.
+      app:
+        condition: service_started
+        required: true
+      postgres:
+        condition: service_healthy
+        required: true
+    restart: 'no'
+
   app:
     pull_policy: build
-    build: .
+    build:
+      context: .
+      target: deploy
     ports:
       - 3000:3000
     environment:


### PR DESCRIPTION
This pull request resolves #135 and adds a dedicated Docker `migrate` stage and a one-shot `migrate` service in `compose.app.yaml` so schema migrations run as a post-startup step.

The Docker Compose wiring makes `migrate` wait for `postgres` health and for `app` to start, avoiding irreversible migrations before basic app startup succeeds. The migration service mounts only the migration runtime files (`package.json`, Drizzle config/migrations/schema) and runs with a non-restarting policy.

## Implementation Notes

- Refactored the Docker stages to split shared dependency setup into a `base` stage.
- Added a `migrate` stage with `ENTRYPOINT ["pnpm", "db:migrate"]`.
- Added `migrate` service dependency gates:
  - `migrate -> postgres` (`service_healthy`, `required: true`)
  - `migrate -> app` (`service_started`, `required: true`)
- Converted migration bind mounts to long-form volume syntax for clarity.

## Test Cases

- [ ] `docker compose --file compose.yaml --file compose.ci.yaml --file compose.prod.yaml --file compose.app.yaml config` succeeds.
- [ ] `pnpm docker:app` starts `app` first, then runs `migrate` after `app` is started and `postgres` is healthy.
- [ ] Migration failure (e.g., invalid `POSTGRES_URL`) does not prevent `app` container startup.
