### PR TITLE
refactor(ui): remove 'Remarks:' prefix

### DIFF
--- a/src/lib/features/student/submission-summary.svelte
+++ b/src/lib/features/student/submission-summary.svelte
@@ -61,9 +61,8 @@
             </div>
             {#if remark.length > 0}
               <div class="text-muted-foreground flex items-center gap-2 p-2 text-sm">
-                <MessageSquare class="size-4" />
-                <div class="flex gap-1">
-                  <span class="font-semibold">Remarks:</span>
+                <div class="flex gap-3">
+                  <MessageSquare class="mt-0.75 size-4 shrink-0" />
                   <p class="italic">
                     {remark}
                   </p>


### PR DESCRIPTION
Removes the "Remarks:" label from the student submission summary view, displaying the remark with an icon instead.

## Implementation Notes

- The remark now displays inline with a message square icon without the "Remarks:" prefix
- Icon alignment adjusted with `mt-0.75` and `shrink-0` for consistent positioning

## Breaking Changes

None.

## Test Cases

- [ ] Verify submission summary displays remarks correctly without the "Remarks:" label