### PR TITLE
fix(app): prevent profile page from crashing due to duplicate student numbers

### DIFF
--- a/src/lib/features/student/profile-setup/index.svelte
+++ b/src/lib/features/student/profile-setup/index.svelte
@@ -39,9 +39,20 @@
             case 'success':
               toast.success('Profile completed.');
               break;
-            case 'failure':
-              toast.error('Failed to complete profile.');
+            case 'failure': {
+              switch (result.status) {
+                case 409:
+                  if (typeof result.data?.message === 'string') {
+                    toast.error(result.data.message);
+                    break;
+                  }
+                // falls through
+                default:
+                  toast.error('Failed to complete profile.');
+                  break;
+              }
               break;
+            }
             default:
               break;
           }

--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -136,13 +136,30 @@ export const actions = {
         'user.family_name': family,
       });
 
-      await updateProfileByUserId(
-        db,
-        user.id,
-        typeof studentNumber === 'undefined' ? null : BigInt(studentNumber),
-        given,
-        family,
-      );
+      try {
+        await updateProfileByUserId(
+          db,
+          user.id,
+          typeof studentNumber === 'undefined' ? null : BigInt(studentNumber),
+          given,
+          family,
+        );
+      } catch (err) {
+        if (
+          err instanceof DrizzleQueryError &&
+          err.cause instanceof DatabaseError &&
+          err.cause.code === '23505'
+        ) {
+          logger.fatal('student number already in use', void 0, {
+            'user.id': user.id,
+            'user.email': user.email,
+            'user.student_number': studentNumber,
+          });
+          return fail(409, { message: 'Student number is already in use.' });
+        }
+        throw err;
+      }
+
       logger.info('profile updated');
     });
   },

--- a/tests/draft.test.ts
+++ b/tests/draft.test.ts
@@ -71,6 +71,25 @@ test.describe('Draft Lifecycle', () => {
       expect(responseData.type).toBe('success');
     });
 
+    test('Patient cannot reuse an existing student number', async ({ patientCandidatePage }) => {
+      await expect(patientCandidatePage.getByText('Complete Your Profile')).toBeVisible();
+      await patientCandidatePage.getByLabel('Student Number').fill('202012345');
+
+      const responsePromise = patientCandidatePage.waitForResponse('/dashboard/?/profile');
+      await patientCandidatePage.getByRole('button', { name: 'Complete Profile' }).click();
+      const response = await responsePromise;
+      const responseData = await response.json();
+
+      expect(response.status()).toBe(200);
+      expect(responseData.type).toBe('failure');
+      expect(responseData.status).toBe(409);
+
+      await expect(patientCandidatePage.getByText('Complete Your Profile')).toBeVisible();
+      await expect(
+        patientCandidatePage.getByText('Student number is already in use.'),
+      ).toBeVisible();
+    });
+
     test('Patient completes profile', async ({ patientCandidatePage }) => {
       await patientCandidatePage.getByLabel('Student Number').fill('202012346');
       const responsePromise = patientCandidatePage.waitForResponse('/dashboard/?/profile');


### PR DESCRIPTION
This pull request closes #171 by preventing the student profile setup flow from crashing when a submitted student number already exists. Instead of bubbling a database unique-constraint error into a `500`, the profile action now returns a graceful SvelteKit form-action failure via `fail(409, { message })`, allowing the UI to handle the conflict predictably.

On the client side, the profile setup form now maps this failure case to a user-facing toast with a clear conflict message, while preserving the existing generic fallback for other failures. This keeps the page stable and gives immediate feedback without a crash.

An end-to-end regression test was added to lock this behavior by submitting a duplicate student number and asserting the non-crashing failure path plus visible error message.

## Implementation Notes

- Server action (`/dashboard/?/profile`) now catches Drizzle/Postgres duplicate-key errors (`23505`) and returns `fail(409, { message: 'Student number is already in use.' })`.
- Student profile setup `use:enhance` failure handling now checks `result.status === 409` and surfaces the server message via toast.
- Playwright coverage includes the duplicate-student-number submission path to prevent regressions.

## Test Cases

- [x] Duplicate student number in profile setup returns an action failure payload (`type: failure`, `status: 409`) instead of crashing the page.
- [x] Duplicate student number shows a user-facing error message and keeps the profile setup UI usable.
- [x] Existing profile setup success paths still work for unique student numbers.
