### PR TITLE
refactor(ui): improve dashboard draft timeline UI

### DIFF
--- a/src/lib/features/drafts/timeline/regular/index.svelte
+++ b/src/lib/features/drafts/timeline/regular/index.svelte
@@ -31,20 +31,22 @@
     if (value === 'students' || value === 'labs' || value === 'logs') group = value;
   }}
 >
-  <Tabs.List>
-    <Tabs.Trigger value="students">
-      <GraduationCapIcon class="size-5" />
-      <span>Registered Students</span>
-    </Tabs.Trigger>
-    <Tabs.Trigger value="labs">
-      <FlaskConicalIcon class="size-5" />
-      <span>Laboratories</span>
-    </Tabs.Trigger>
-    <Tabs.Trigger value="logs">
-      <PaperclipIcon class="size-5" />
-      <span>System Logs</span>
-    </Tabs.Trigger>
-  </Tabs.List>
+  <div class="min-w-0 overflow-auto">
+    <Tabs.List>
+      <Tabs.Trigger value="students">
+        <GraduationCapIcon class="size-5" />
+        <span>Registered Students</span>
+      </Tabs.Trigger>
+      <Tabs.Trigger value="labs">
+        <FlaskConicalIcon class="size-5" />
+        <span>Laboratories</span>
+      </Tabs.Trigger>
+      <Tabs.Trigger value="logs">
+        <PaperclipIcon class="size-5" />
+        <span>System Logs</span>
+      </Tabs.Trigger>
+    </Tabs.List>
+  </div>
   <Tabs.Content value="students">
     <div class="flex items-center justify-around">
       <AvailableDraftees {draftId} variant="pending-selection"

--- a/src/lib/features/drafts/timeline/regular/system-logs-tab.svelte
+++ b/src/lib/features/drafts/timeline/regular/system-logs-tab.svelte
@@ -76,15 +76,14 @@ Needs to distinguish the following events (one 'event' being a grouping of choic
 4. Lab received no interest, was auto-skipped [null faculty email, none of the above cases]
 -->
 
-<label class="flex items-center space-x-2 mt-4">
+<label class="mt-4 flex items-center space-x-2">
   <input
-    class="border-primary h-4 w-4 rounded-lg border"
+    class="h-4 w-4 rounded-lg border border-primary"
     type="checkbox"
     bind:checked={showAutomated}
   />
   <span>Show System Automation Logs</span>
 </label>
-
 
 <div class="my-4 overflow-x-auto rounded-lg border">
   <table class="w-full">
@@ -115,9 +114,8 @@ Needs to distinguish the following events (one 'event' being a grouping of choic
                 {:else if choice.studentEmail === null}
                   <!-- If a faculty member selected no students -->
                   <span>
-                    <Badge
-                      variant="outline"
-                      class="border-primary bg-primary/10 text-primary">No</Badge
+                    <Badge variant="outline" class="border-primary bg-primary/10 text-primary"
+                      >No</Badge
                     >
                     students selected
                   </span>
@@ -136,16 +134,15 @@ Needs to distinguish the following events (one 'event' being a grouping of choic
               <td class="p-1">
                 {#if choice.userEmail === null}
                   <Badge
-                        variant="outline"
-                        class="border-secondary bg-secondary/10 text-secondary-foreground"
-                        >System</Badge
-                      >
+                    variant="outline"
+                    class="border-secondary bg-secondary/10 text-secondary-foreground">System</Badge
+                  >
                 {:else}
                   <Badge
-                        variant="outline"
-                        class="border-secondary bg-secondary/10 text-secondary-foreground"
-                        >{choice.userEmail}</Badge
-                      >
+                    variant="outline"
+                    class="border-secondary bg-secondary/10 text-secondary-foreground"
+                    >{choice.userEmail}</Badge
+                  >
                 {/if}
               </td>
             </tr>

--- a/src/lib/features/drafts/timeline/regular/system-logs-tab.svelte
+++ b/src/lib/features/drafts/timeline/regular/system-logs-tab.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { fromUnixTime, getUnixTime } from 'date-fns';
 
-  import * as Card from '$lib/components/ui/card';
   import { Badge } from '$lib/components/ui/badge';
 
   import type { FacultyChoiceRecord } from '$lib/features/drafts/types';

--- a/src/lib/features/drafts/timeline/regular/system-logs-tab.svelte
+++ b/src/lib/features/drafts/timeline/regular/system-logs-tab.svelte
@@ -114,7 +114,7 @@ Needs to distinguish the following events (one 'event' being a grouping of choic
                 {:else if choice.studentEmail === null}
                   <!-- If a faculty member selected no students -->
                   <span>
-                    <Badge variant="outline" class="border-primary bg-primary/10 text-primary"
+                    <Badge variant="outline" class="border-primary bg-primary/10 text-primary dark:border-secondary dark:bg-secondary/10 dark:text-secondary"
                       >No</Badge
                     >
                     students selected
@@ -124,7 +124,7 @@ Needs to distinguish the following events (one 'event' being a grouping of choic
                   <span>
                     Selected
                     {#each lab.choices as { studentEmail } (studentEmail)}
-                      <Badge variant="outline" class="border-primary bg-primary/10 text-primary"
+                      <Badge variant="outline" class="border-primary bg-primary/10 text-primary dark:border-secondary dark:bg-secondary/10 dark:text-secondary"
                         >{studentEmail}</Badge
                       >
                     {/each}
@@ -135,12 +135,12 @@ Needs to distinguish the following events (one 'event' being a grouping of choic
                 {#if choice.userEmail === null}
                   <Badge
                     variant="outline"
-                    class="border-secondary bg-secondary/10 text-secondary-foreground">System</Badge
+                    class="border-secondary bg-secondary/10 text-secondary-foreground dark:text-secondary">System</Badge
                   >
                 {:else}
                   <Badge
                     variant="outline"
-                    class="border-secondary bg-secondary/10 text-secondary-foreground"
+                    class="border-secondary bg-secondary/10 text-secondary-foreground dark:text-secondary"
                     >{choice.userEmail}</Badge
                   >
                 {/if}

--- a/src/lib/features/drafts/timeline/regular/system-logs-tab.svelte
+++ b/src/lib/features/drafts/timeline/regular/system-logs-tab.svelte
@@ -89,11 +89,11 @@ Needs to distinguish the following events (one 'event' being a grouping of choic
   <table class="w-full">
     <thead class="text-left">
       <tr class="border-b">
-        <th class="py-2 px-4 whitespace-nowrap">Timestamp</th>
-        <th class="py-2 px-4 whitespace-nowrap">Round</th>
-        <th class="py-2 px-4 whitespace-nowrap">Lab ID</th>
-        <th class="py-2 px-4 whitespace-nowrap">Action</th>
-        <th class="py-2 px-4 whitespace-nowrap">Actor</th>
+        <th class="px-4 py-2 whitespace-nowrap">Timestamp</th>
+        <th class="px-4 py-2 whitespace-nowrap">Round</th>
+        <th class="px-4 py-2 whitespace-nowrap">Lab ID</th>
+        <th class="px-4 py-2 whitespace-nowrap">Action</th>
+        <th class="px-4 py-2 whitespace-nowrap">Actor</th>
       </tr>
     </thead>
 
@@ -104,17 +104,21 @@ Needs to distinguish the following events (one 'event' being a grouping of choic
 
           {#if typeof choice !== 'undefined'}
             <tr class="border-t">
-              <td class="py-2 px-4 whitespace-nowrap">{fromUnixTime(event.unix).toLocaleString()}</td>
-              <td class="py-2 px-4 whitespace-nowrap">{lab.round}</td>
-              <td class="py-2 px-4 whitespace-nowrap uppercase">{lab.labId}</td>
-              <td class="py-2 px-4 whitespace-nowrap">
+              <td class="px-4 py-2 whitespace-nowrap"
+                >{fromUnixTime(event.unix).toLocaleString()}</td
+              >
+              <td class="px-4 py-2 whitespace-nowrap">{lab.round}</td>
+              <td class="px-4 py-2 whitespace-nowrap uppercase">{lab.labId}</td>
+              <td class="px-4 py-2 whitespace-nowrap">
                 {#if choice.userEmail === null}
                   <!-- If the system auto-skipped -->
                   <span>System automation</span>
                 {:else if choice.studentEmail === null}
                   <!-- If a faculty member selected no students -->
                   <span>
-                    <Badge variant="outline" class="border-primary bg-primary/10 text-primary dark:border-secondary dark:bg-secondary/10 dark:text-secondary"
+                    <Badge
+                      variant="outline"
+                      class="border-primary bg-primary/10 text-primary dark:border-secondary dark:bg-secondary/10 dark:text-secondary"
                       >No</Badge
                     >
                     students selected
@@ -124,18 +128,21 @@ Needs to distinguish the following events (one 'event' being a grouping of choic
                   <span>
                     Selected
                     {#each lab.choices as { studentEmail } (studentEmail)}
-                      <Badge variant="outline" class="border-primary bg-primary/10 text-primary dark:border-secondary dark:bg-secondary/10 dark:text-secondary"
+                      <Badge
+                        variant="outline"
+                        class="border-primary bg-primary/10 text-primary dark:border-secondary dark:bg-secondary/10 dark:text-secondary"
                         >{studentEmail}</Badge
                       >
                     {/each}
                   </span>
                 {/if}
               </td>
-              <td class="py-2 px-4 whitespace-nowrap">
+              <td class="px-4 py-2 whitespace-nowrap">
                 {#if choice.userEmail === null}
                   <Badge
                     variant="outline"
-                    class="border-secondary bg-secondary/10 text-secondary-foreground dark:text-secondary">System</Badge
+                    class="border-secondary bg-secondary/10 text-secondary-foreground dark:text-secondary"
+                    >System</Badge
                   >
                 {:else}
                   <Badge

--- a/src/lib/features/drafts/timeline/regular/system-logs-tab.svelte
+++ b/src/lib/features/drafts/timeline/regular/system-logs-tab.svelte
@@ -89,7 +89,7 @@ Needs to distinguish the following events (one 'event' being a grouping of choic
   <table class="w-full">
     <thead class="text-left">
       <tr class="border-b">
-        <th class="p-1">Timestamp (GMT+8)</th>
+        <th class="p-1">Timestamp</th>
         <th class="p-1">Lab ID</th>
         <th class="p-1">Round</th>
         <th class="p-1">Action</th>

--- a/src/lib/features/drafts/timeline/regular/system-logs-tab.svelte
+++ b/src/lib/features/drafts/timeline/regular/system-logs-tab.svelte
@@ -89,11 +89,11 @@ Needs to distinguish the following events (one 'event' being a grouping of choic
   <table class="w-full">
     <thead class="text-left">
       <tr class="border-b">
-        <th class="p-1">Timestamp</th>
-        <th class="p-1">Lab ID</th>
-        <th class="p-1">Round</th>
-        <th class="p-1">Action</th>
-        <th class="p-1">Actor</th>
+        <th class="p-1 whitespace-nowrap">Timestamp</th>
+        <th class="p-1 whitespace-nowrap">Round</th>
+        <th class="p-1 whitespace-nowrap">Lab ID</th>
+        <th class="p-1 whitespace-nowrap">Action</th>
+        <th class="p-1 whitespace-nowrap">Actor</th>
       </tr>
     </thead>
 
@@ -105,8 +105,8 @@ Needs to distinguish the following events (one 'event' being a grouping of choic
           {#if typeof choice !== 'undefined'}
             <tr class="border-t">
               <td class="p-1 whitespace-nowrap">{fromUnixTime(event.unix).toLocaleString()}</td>
-              <td class="p-1 whitespace-nowrap uppercase">{lab.labId}</td>
               <td class="p-1 whitespace-nowrap">{lab.round}</td>
+              <td class="p-1 whitespace-nowrap uppercase">{lab.labId}</td>
               <td class="p-1 whitespace-nowrap">
                 {#if choice.userEmail === null}
                   <!-- If the system auto-skipped -->

--- a/src/lib/features/drafts/timeline/regular/system-logs-tab.svelte
+++ b/src/lib/features/drafts/timeline/regular/system-logs-tab.svelte
@@ -16,7 +16,7 @@
   interface SystemLogLabGroup {
     key: string;
     labId: string;
-    round: 'Lottery' | `Round ${number}`;
+    round: 'Lottery' | `${number}`;
     choices: FacultyChoiceRecord[];
   }
 
@@ -50,7 +50,7 @@
         labGroup = {
           key: eventLabKey,
           labId: choice.labId,
-          round: choice.round === null ? 'Lottery' : `Round ${choice.round}`,
+          round: choice.round === null ? 'Lottery' : `${choice.round}`,
           choices: [],
         };
         labByEventAndLabKey[eventLabKey] = labGroup;
@@ -89,11 +89,11 @@ Needs to distinguish the following events (one 'event' being a grouping of choic
   <table class="w-full">
     <thead class="text-left">
       <tr class="border-b">
-        <th class="p-1 whitespace-nowrap">Timestamp</th>
-        <th class="p-1 whitespace-nowrap">Round</th>
-        <th class="p-1 whitespace-nowrap">Lab ID</th>
-        <th class="p-1 whitespace-nowrap">Action</th>
-        <th class="p-1 whitespace-nowrap">Actor</th>
+        <th class="py-2 px-4 whitespace-nowrap">Timestamp</th>
+        <th class="py-2 px-4 whitespace-nowrap">Round</th>
+        <th class="py-2 px-4 whitespace-nowrap">Lab ID</th>
+        <th class="py-2 px-4 whitespace-nowrap">Action</th>
+        <th class="py-2 px-4 whitespace-nowrap">Actor</th>
       </tr>
     </thead>
 
@@ -104,10 +104,10 @@ Needs to distinguish the following events (one 'event' being a grouping of choic
 
           {#if typeof choice !== 'undefined'}
             <tr class="border-t">
-              <td class="p-1 whitespace-nowrap">{fromUnixTime(event.unix).toLocaleString()}</td>
-              <td class="p-1 whitespace-nowrap">{lab.round}</td>
-              <td class="p-1 whitespace-nowrap uppercase">{lab.labId}</td>
-              <td class="p-1 whitespace-nowrap">
+              <td class="py-2 px-4 whitespace-nowrap">{fromUnixTime(event.unix).toLocaleString()}</td>
+              <td class="py-2 px-4 whitespace-nowrap">{lab.round}</td>
+              <td class="py-2 px-4 whitespace-nowrap uppercase">{lab.labId}</td>
+              <td class="py-2 px-4 whitespace-nowrap">
                 {#if choice.userEmail === null}
                   <!-- If the system auto-skipped -->
                   <span>System automation</span>
@@ -131,7 +131,7 @@ Needs to distinguish the following events (one 'event' being a grouping of choic
                   </span>
                 {/if}
               </td>
-              <td class="p-1 whitespace-nowrap">
+              <td class="py-2 px-4 whitespace-nowrap">
                 {#if choice.userEmail === null}
                   <Badge
                     variant="outline"

--- a/src/lib/features/drafts/timeline/regular/system-logs-tab.svelte
+++ b/src/lib/features/drafts/timeline/regular/system-logs-tab.svelte
@@ -85,7 +85,7 @@ Needs to distinguish the following events (one 'event' being a grouping of choic
   <span>Show System Automation Logs</span>
 </label>
 
-<div class="my-4 overflow-x-auto rounded-lg border">
+<div class="my-4 overflow-auto rounded-lg border">
   <table class="w-full">
     <thead class="text-left">
       <tr class="border-b">
@@ -104,10 +104,10 @@ Needs to distinguish the following events (one 'event' being a grouping of choic
 
           {#if typeof choice !== 'undefined'}
             <tr class="border-t">
-              <td class="p-1">{fromUnixTime(event.unix).toLocaleString()}</td>
-              <td class="p-1 uppercase">{lab.labId}</td>
-              <td class="p-1">{lab.round}</td>
-              <td class="p-1">
+              <td class="p-1 whitespace-nowrap">{fromUnixTime(event.unix).toLocaleString()}</td>
+              <td class="p-1 whitespace-nowrap uppercase">{lab.labId}</td>
+              <td class="p-1 whitespace-nowrap">{lab.round}</td>
+              <td class="p-1 whitespace-nowrap">
                 {#if choice.userEmail === null}
                   <!-- If the system auto-skipped -->
                   <span>System automation</span>
@@ -131,7 +131,7 @@ Needs to distinguish the following events (one 'event' being a grouping of choic
                   </span>
                 {/if}
               </td>
-              <td class="p-1">
+              <td class="p-1 whitespace-nowrap">
                 {#if choice.userEmail === null}
                   <Badge
                     variant="outline"

--- a/src/lib/features/drafts/timeline/regular/system-logs-tab.svelte
+++ b/src/lib/features/drafts/timeline/regular/system-logs-tab.svelte
@@ -79,63 +79,80 @@ Needs to distinguish the following events (one 'event' being a grouping of choic
 
 <label class="flex items-center space-x-2 mt-4">
   <input
-    class="border-primary h-4 w-4 rounded border"
+    class="border-primary h-4 w-4 rounded-lg border"
     type="checkbox"
     bind:checked={showAutomated}
   />
   <span>Show System Automation Logs</span>
 </label>
 
-{#each events as event (event.key)}
-  <Card.Root class="my-2">
-    <Card.Header>
-      <Card.Title class="text-base">{fromUnixTime(event.unix).toLocaleString()}</Card.Title>
-    </Card.Header>
-    <Card.Content class="space-y-4">
-      {#each event.labs as lab (lab.key)}
-        {@const [choice] = lab.choices}
-        {#if typeof choice !== 'undefined'}
-          <div class="space-y-1 rounded-md bg-muted p-4">
-            <strong class="uppercase">{lab.labId}</strong> ({lab.round}):
-            {#if choice.userEmail === null || choice.studentEmail === null}
-              {#if choice.userEmail === null}
-                <!-- If the system auto-skipped -->
-                <span>This selection was automated by the system</span>
-              {:else}
-                <!-- If a faculty member selected no students -->
-                <span>
-                  This selection of <Badge
-                    variant="outline"
-                    class="border-primary bg-primary/10 text-primary">no</Badge
-                  >
-                  students was performed by faculty member
+
+<div class="my-4 overflow-x-auto rounded-lg border">
+  <table class="w-full">
+    <thead class="text-left">
+      <tr class="border-b">
+        <th class="p-1">Timestamp (GMT+8)</th>
+        <th class="p-1">Lab ID</th>
+        <th class="p-1">Round</th>
+        <th class="p-1">Action</th>
+        <th class="p-1">Actor</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      {#each events as event (event.key)}
+        {#each event.labs as lab (lab.key)}
+          {@const [choice] = lab.choices}
+
+          {#if typeof choice !== 'undefined'}
+            <tr class="border-t">
+              <td class="p-1">{fromUnixTime(event.unix).toLocaleString()}</td>
+              <td class="p-1 uppercase">{lab.labId}</td>
+              <td class="p-1">{lab.round}</td>
+              <td class="p-1">
+                {#if choice.userEmail === null}
+                  <!-- If the system auto-skipped -->
+                  <span>System automation</span>
+                {:else if choice.studentEmail === null}
+                  <!-- If a faculty member selected no students -->
+                  <span>
+                    <Badge
+                      variant="outline"
+                      class="border-primary bg-primary/10 text-primary">No</Badge
+                    >
+                    students selected
+                  </span>
+                {:else}
+                  <!-- If a faculty member selected students -->
+                  <span>
+                    Selected
+                    {#each lab.choices as { studentEmail } (studentEmail)}
+                      <Badge variant="outline" class="border-primary bg-primary/10 text-primary"
+                        >{studentEmail}</Badge
+                      >
+                    {/each}
+                  </span>
+                {/if}
+              </td>
+              <td class="p-1">
+                {#if choice.userEmail === null}
                   <Badge
-                    variant="outline"
-                    class="border-secondary bg-secondary/10 text-secondary-foreground"
-                    >{choice.userEmail}</Badge
-                  >
-                </span>
-              {/if}
-            {:else}
-              <!-- If a faculty member selected students -->
-              <span>
-                This selection of
-                {#each lab.choices as { studentEmail } (studentEmail)}
-                  <Badge variant="outline" class="border-primary bg-primary/10 text-primary"
-                    >{studentEmail}</Badge
-                  >
-                {/each}
-                was performed by
-                <Badge
-                  variant="outline"
-                  class="border-secondary bg-secondary/10 text-secondary-foreground"
-                  >{choice.userEmail}</Badge
-                >
-              </span>
-            {/if}
-          </div>
-        {/if}
+                        variant="outline"
+                        class="border-secondary bg-secondary/10 text-secondary-foreground"
+                        >System</Badge
+                      >
+                {:else}
+                  <Badge
+                        variant="outline"
+                        class="border-secondary bg-secondary/10 text-secondary-foreground"
+                        >{choice.userEmail}</Badge
+                      >
+                {/if}
+              </td>
+            </tr>
+          {/if}
+        {/each}
       {/each}
-    </Card.Content>
-  </Card.Root>
-{/each}
+    </tbody>
+  </table>
+</div>

--- a/src/lib/features/drafts/timeline/regular/system-logs-tab.svelte
+++ b/src/lib/features/drafts/timeline/regular/system-logs-tab.svelte
@@ -16,7 +16,7 @@
   interface SystemLogLabGroup {
     key: string;
     labId: string;
-    round: 'Lottery' | `${number}`;
+    round: 'Lottery' | number;
     choices: FacultyChoiceRecord[];
   }
 
@@ -50,7 +50,7 @@
         labGroup = {
           key: eventLabKey,
           labId: choice.labId,
-          round: choice.round === null ? 'Lottery' : `${choice.round}`,
+          round: choice.round === null ? 'Lottery' : choice.round,
           choices: [],
         };
         labByEventAndLabKey[eventLabKey] = labGroup;

--- a/src/lib/features/drafts/timeline/regular/system-logs-tab.svelte
+++ b/src/lib/features/drafts/timeline/regular/system-logs-tab.svelte
@@ -77,18 +77,15 @@ Needs to distinguish the following events (one 'event' being a grouping of choic
 4. Lab received no interest, was auto-skipped [null faculty email, none of the above cases]
 -->
 
-<Card.Root class="my-2">
-  <Card.Content class="pt-4">
-    <label class="flex items-center space-x-2">
-      <input
-        class="h-4 w-4 rounded border border-primary"
-        type="checkbox"
-        bind:checked={showAutomated}
-      />
-      <span>Show System Automation Logs</span>
-    </label>
-  </Card.Content>
-</Card.Root>
+<label class="flex items-center space-x-2 mt-4">
+  <input
+    class="border-primary h-4 w-4 rounded border"
+    type="checkbox"
+    bind:checked={showAutomated}
+  />
+  <span>Show System Automation Logs</span>
+</label>
+
 {#each events as event (event.key)}
   <Card.Root class="my-2">
     <Card.Header>

--- a/src/lib/features/drafts/timeline/step.svelte
+++ b/src/lib/features/drafts/timeline/step.svelte
@@ -8,8 +8,6 @@
   import CircleIcon from '@lucide/svelte/icons/circle';
   import type { Snippet } from 'svelte';
 
-  import { tv } from 'tailwind-variants';
-
   import * as Collapsible from '$lib/components/ui/collapsible';
 
   interface Props {
@@ -33,17 +31,6 @@
   }: Props = $props();
 
   let open = $derived(defaultOpen);
-
-  // const contentVariants = tv({
-  //   base: 'mt-3 rounded-lg p-4',
-  //   variants: {
-  //     status: {
-  //       completed: 'bg-card',
-  //       active: 'bg-card',
-  //       pending: '',
-  //     },
-  //   },
-  // });
 </script>
 
 <div class="relative flex gap-4">

--- a/src/lib/features/drafts/timeline/step.svelte
+++ b/src/lib/features/drafts/timeline/step.svelte
@@ -70,7 +70,7 @@
           />
         </Collapsible.Trigger>
         <Collapsible.Content>
-          <div class="rounded-lg p-4 bg-background">
+          <div class="rounded-lg bg-background p-4">
             {@render children()}
           </div>
         </Collapsible.Content>
@@ -83,7 +83,7 @@
           {@render metadata()}
         {/if}
       </div>
-      <div class="rounded-lg p-4 bg-background">
+      <div class="rounded-lg bg-background p-4">
         {@render children()}
       </div>
     {/if}

--- a/src/lib/features/drafts/timeline/step.svelte
+++ b/src/lib/features/drafts/timeline/step.svelte
@@ -53,7 +53,7 @@
   </div>
 
   <!-- Content area -->
-  <div class="flex-1 pb-6">
+  <div class="min-w-0 flex-1 pb-6">
     {#if collapsible}
       <Collapsible.Root bind:open>
         <Collapsible.Trigger

--- a/src/lib/features/drafts/timeline/step.svelte
+++ b/src/lib/features/drafts/timeline/step.svelte
@@ -34,16 +34,16 @@
 
   let open = $derived(defaultOpen);
 
-  const contentVariants = tv({
-    base: 'mt-3 rounded-lg p-4',
-    variants: {
-      status: {
-        completed: 'bg-card',
-        active: 'bg-card',
-        pending: '',
-      },
-    },
-  });
+  // const contentVariants = tv({
+  //   base: 'mt-3 rounded-lg p-4',
+  //   variants: {
+  //     status: {
+  //       completed: 'bg-card',
+  //       active: 'bg-card',
+  //       pending: '',
+  //     },
+  //   },
+  // });
 </script>
 
 <div class="relative flex gap-4">
@@ -83,7 +83,7 @@
           />
         </Collapsible.Trigger>
         <Collapsible.Content>
-          <div class={contentVariants({ status })}>
+          <div class="rounded-lg p-4 bg-background">
             {@render children()}
           </div>
         </Collapsible.Content>
@@ -96,7 +96,7 @@
           {@render metadata()}
         {/if}
       </div>
-      <div class={contentVariants({ status })}>
+      <div class="rounded-lg p-4 bg-background">
         {@render children()}
       </div>
     {/if}


### PR DESCRIPTION
This PR makes a few small changes for the UI of the draft timeline in the dashboard to reduce nested components. This foregoes the use of the `Card` component in the system logs to make the timeline look more easily readable, along with changing some text and background styling choices. This PR closes #184.

## Implementation Notes
- Replaced the use of the Card component in `system-logs-tab.svelte` in favor of a normal table format
- Changed some background styling variants in `step.svelte` to reduce nested styling
- Changed some text in the system logs to be less verbose

## Breaking Changes

- On small viewports, the table makes the whole page scroll instead of just the table scrolling despite having the overflow-auto property
  - Styling and background colors still render properly, but this should be fixed before merging to avoid the table looking unprofessional

## Test Cases

Communicate to the code reviewer that the following test cases have been considered and tested by the author. The author will be able to use this as their own personal checklist before publication.

- [ ] System logs table renders correctly on desktop/mobile
- [ ] Automated logs should be properly toggleable with the checkbox
- [ ] Table should be scrollable instead of text wrapping
