### PR TITLE
fix(ui): hoist bottom nav to in-flow flexbox shell layout

### DIFF
--- a/src/lib/components/bottom-nav.svelte
+++ b/src/lib/components/bottom-nav.svelte
@@ -6,12 +6,13 @@
   import { cn } from '$lib/components/ui/utils';
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
+  import { useSidebar } from '$lib/components/ui/sidebar';
 
-  let { sidebar } = $props();
+  const sidebar = useSidebar();
 </script>
 
 <menu
-  class="flex w-full items-center justify-between gap-2 border-t border-border bg-background/90 px-10 py-2 backdrop-blur-md"
+  class="flex w-full items-center justify-between gap-2 border-t border-border bg-background/90 px-10 py-2 backdrop-blur-md md:hidden"
 >
   <li class="flex size-12 place-content-center items-center">
     <button
@@ -22,7 +23,6 @@
       <span class="sr-only">Toggle Sidebar</span>
     </button>
   </li>
-
   <li class="flex size-12 place-content-center items-center">
     <div
       class={cn(
@@ -38,7 +38,6 @@
       </a>
     </div>
   </li>
-
   <li class="flex size-12 place-content-center items-center">
     <a
       href={resolve('/')}

--- a/src/routes/dashboard/+layout.svelte
+++ b/src/routes/dashboard/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import BottomNav from '$lib/components/bottom-nav.svelte';
   import { dev } from '$app/environment';
   import { DevTools } from '$lib/features/dev-tools';
   import { SidebarProvider } from '$lib/components/ui/sidebar';
@@ -14,9 +15,12 @@
 <SidebarProvider>
   <div class="flex h-dvh w-full overflow-hidden">
     <SideBar {user} />
-    <main class="grow space-y-4 overflow-y-auto px-4 pt-16 pb-20 md:pt-4 md:pb-0">
-      {@render children?.()}
-    </main>
+    <div class="flex min-w-0 flex-1 flex-col">
+      <main class="grow space-y-4 overflow-y-auto px-4 pt-4">
+        {@render children?.()}
+      </main>
+      <BottomNav />
+    </div>
   </div>
 </SidebarProvider>
 {#if dev && typeof user !== 'undefined'}

--- a/src/routes/dashboard/side-bar.svelte
+++ b/src/routes/dashboard/side-bar.svelte
@@ -14,7 +14,6 @@
   import * as Avatar from '$lib/components/ui/avatar';
   import * as Drawer from '$lib/components/ui/drawer';
   import * as Sidebar from '$lib/components/ui/sidebar';
-  import BottomNav from '$lib/components/bottom-nav.svelte';
   import Button from '$lib/components/ui/button/button.svelte';
   import Logo from '$lib/assets/logo-DRAP-icon-colored.svg';
   import ModeSwitcher from '$lib/components/mode-switcher.svelte';
@@ -24,7 +23,6 @@
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
   import type { schema } from '$lib/server/database/drizzle';
-  import { TooltipProvider } from '$lib/components/ui/tooltip';
 
   interface Props {
     user?: schema.User;
@@ -340,35 +338,28 @@
   </Sidebar.Footer>
 {/snippet}
 
-<TooltipProvider>
-  {#if !sidebar.openMobile}
-    <div class="fixed bottom-0 z-45 w-full md:hidden">
-      <BottomNav {sidebar} />
-    </div>
-  {/if}
-  {#if sidebar.isMobile}
-    <Drawer.Root
-      bind:open={() => sidebar.openMobile, v => sidebar.setOpenMobile(v)}
-      direction="bottom"
+{#if sidebar.isMobile}
+  <Drawer.Root
+    bind:open={() => sidebar.openMobile, v => sidebar.setOpenMobile(v)}
+    direction="bottom"
+  >
+    <Drawer.Content
+      data-sidebar="sidebar"
+      data-slot="sidebar"
+      data-mobile="true"
+      class="w-dvw bg-sidebar p-0 text-sidebar-foreground"
     >
-      <Drawer.Content
-        data-sidebar="sidebar"
-        data-slot="sidebar"
-        data-mobile="true"
-        class="w-dvw bg-sidebar p-0 text-sidebar-foreground"
-      >
-        <Drawer.Header class="sr-only">
-          <Drawer.Title>Sidebar</Drawer.Title>
-          <Drawer.Description>Displays the mobile sidebar.</Drawer.Description>
-        </Drawer.Header>
-        <div class="flex h-full w-full flex-col">
-          {@render sidebarSections()}
-        </div>
-      </Drawer.Content>
-    </Drawer.Root>
-  {:else}
-    <Sidebar.Root collapsible="icon" class="border-r border-border">
-      {@render sidebarSections()}
-    </Sidebar.Root>
-  {/if}
-</TooltipProvider>
+      <Drawer.Header class="sr-only">
+        <Drawer.Title>Sidebar</Drawer.Title>
+        <Drawer.Description>Displays the mobile sidebar.</Drawer.Description>
+      </Drawer.Header>
+      <div class="flex h-full w-full flex-col">
+        {@render sidebarSections()}
+      </div>
+    </Drawer.Content>
+  </Drawer.Root>
+{:else}
+  <Sidebar.Root collapsible="icon" class="border-r border-border">
+    {@render sidebarSections()}
+  </Sidebar.Root>
+{/if}


### PR DESCRIPTION
Replace the fixed-position mobile bottom nav with an in-flow flexbox layout. Previously, `<BottomNav>` used `fixed bottom-0` which overlayed page content, requiring a `pb-20` padding hack on `<main>`. Now the dashboard shell uses a column flex container where `<main>` grows to fill available space and the bottom nav sits naturally below it.

## Implementation Notes

- **`bottom-nav.svelte`** now calls `useSidebar()` internally instead of receiving `sidebar` as a prop, making it self-contained and placeable anywhere within `SidebarProvider`.
- **`+layout.svelte`** wraps `<main>` and `<BottomNav />` in a `flex min-w-0 flex-1 flex-col` container. The `min-w-0` prevents wide content (tables, pre blocks) from causing horizontal overflow.
- **`side-bar.svelte`** no longer renders the bottom nav or its fixed-position wrapper. The redundant `<TooltipProvider>` wrapper was also removed since `sidebar-provider.svelte` already provides one.
- Normalized `pt-16 md:pt-4` to `pt-4` on `<main>` (the 64px mobile-only top padding had no corresponding fixed top element).

## Test Cases

- [ ] Mobile: bottom nav is visible at the bottom of the viewport
- [ ] Mobile: page content scrolls fully without being clipped behind the bottom nav
- [ ] Mobile: sidebar drawer opens over the bottom nav without layout shift
- [ ] Mobile: sidebar toggle button in bottom nav still opens/closes the drawer
- [ ] Desktop: bottom nav is hidden, sidebar is visible on the left
- [ ] Desktop: collapsing/expanding the sidebar still works correctly
- [ ] Desktop: no layout regression in the main content area
