### PR TITLE
fix: use destructive color for toast close button

### DIFF
--- a/src/lib/components/ui/sonner/sonner.css
+++ b/src/lib/components/ui/sonner/sonner.css
@@ -1,11 +1,20 @@
 .toaster[data-sonner-toaster][data-sonner-theme='light'],
 .toaster[data-sonner-toaster][data-sonner-theme='dark'] {
   --success-bg: var(--color-success);
-  --success-text: var(--color-success-foreground);
+  --success-text: var(--color-primary-foreground);
   --error-bg: var(--color-destructive);
   --error-text: var(--color-destructive-foreground);
   --warning-bg: var(--color-warning);
   --warning-text: var(--color-warning-foreground);
   --info-bg: var(--color-accent);
   --info-text: var(--color-accent-foreground);
+}
+
+.toaster[data-sonner-toaster] :where([data-sonner-toast]):hover :where([data-close-button]):hover {
+  background: color-mix(in srgb, var(--color-destructive), var(--color-background)) !important;
+}
+.toaster[data-sonner-toaster][data-sonner-theme='dark']
+  :where([data-sonner-toast]):hover
+  :where([data-close-button]):hover {
+  background: color-mix(in srgb, var(--color-destructive), var(--color-foreground)) !important;
 }


### PR DESCRIPTION
Tiny PR that closes #230 
✨ Use a color based on the destructive color and background color for the toast close buttons

<img width="939" height="459" alt="89btPwX3SP" src="https://github.com/user-attachments/assets/f0913eb7-3698-4daa-8547-448190303f70" />
