### PR TITLE
fix(draft): separate conclusion and finalization emails

### DIFF
--- a/src/lib/features/dev-tools/email-dispatcher/form.svelte
+++ b/src/lib/features/dev-tools/email-dispatcher/form.svelte
@@ -80,7 +80,7 @@
           >Draft Concluded</NativeSelect.Option
         >
         <NativeSelect.Option value="draft/draft.finalization.email.batch"
-          >Draft Finalization</NativeSelect.Option
+          >Draft Finalized</NativeSelect.Option
         >
         <NativeSelect.Option value="draft/user.assigned.email.batch"
           >User Assigned</NativeSelect.Option

--- a/src/lib/features/dev-tools/email-dispatcher/form.svelte
+++ b/src/lib/features/dev-tools/email-dispatcher/form.svelte
@@ -76,8 +76,11 @@
         <NativeSelect.Option value="draft/lottery.intervened.email.batch"
           >Lottery Intervened</NativeSelect.Option
         >
-        <NativeSelect.Option value="draft/draft.finalized.email.batch"
-          >Draft Finalized</NativeSelect.Option
+        <NativeSelect.Option value="draft/draft.concluded.email.batch"
+          >Draft Concluded</NativeSelect.Option
+        >
+        <NativeSelect.Option value="draft/draft.finalization.email.batch"
+          >Draft Finalization</NativeSelect.Option
         >
         <NativeSelect.Option value="draft/user.assigned.email.batch"
           >User Assigned</NativeSelect.Option
@@ -168,7 +171,7 @@
           placeholder="example@up.edu.ph"
         />
       </div>
-    {:else if selectedEvent === 'draft/draft.finalized.email.batch'}
+    {:else if selectedEvent === 'draft/draft.concluded.email.batch'}
       <div class="space-y-2">
         <Label for="draftId">Draft ID</Label>
         <Input type="number" name="draftId" id="draftId" min="1" required placeholder="1" />
@@ -184,6 +187,21 @@
         />
       </div>
       <LotteryAssignmentsInput />
+    {:else if selectedEvent === 'draft/draft.finalization.email.batch'}
+      <div class="space-y-2">
+        <Label for="draftId">Draft ID</Label>
+        <Input type="number" name="draftId" id="draftId" min="1" required placeholder="1" />
+      </div>
+      <div class="space-y-2">
+        <Label for="recipientEmail">Recipient Email</Label>
+        <Input
+          type="email"
+          name="recipientEmail"
+          id="recipientEmail"
+          required
+          placeholder="example@up.edu.ph"
+        />
+      </div>
     {:else if selectedEvent === 'draft/user.assigned.email.batch'}
       <div class="space-y-2">
         <Label for="labId">Lab ID</Label>

--- a/src/lib/features/dev-tools/index.svelte
+++ b/src/lib/features/dev-tools/index.svelte
@@ -34,7 +34,7 @@
           {...props}
           variant="outline"
           size="icon-lg"
-          class="bg-background hover:bg-accent dark:bg-input dark:hover:bg-input/80"
+          class="bg-background hover:bg-accent dark:bg-input dark:hover:bg-input"
         >
           <BugIcon class="size-4" />
         </Button>

--- a/src/lib/server/database/drizzle.ts
+++ b/src/lib/server/database/drizzle.ts
@@ -151,6 +151,29 @@ export async function getFacultyAndStaff(db: DbConnection) {
   });
 }
 
+export async function getDraftAdmins(db: DbConnection) {
+  return await tracer.asyncSpan(
+    'get-draft-admins',
+    async () =>
+      await db
+        .select({
+          id: schema.user.id,
+          email: schema.user.email,
+          givenName: schema.user.givenName,
+          familyName: schema.user.familyName,
+          avatarUrl: schema.user.avatarUrl,
+        })
+        .from(schema.user)
+        .where(
+          and(
+            eq(schema.user.isAdmin, true),
+            isNotNull(schema.user.googleUserId),
+            isNull(schema.user.labId),
+          ),
+        ),
+  );
+}
+
 export async function getDraftNotificationRecipients(db: DbConnection, draftId: bigint) {
   return await tracer.asyncSpan('get-draft-notification-recipients', async span => {
     span.setAttribute('database.draft.id', draftId.toString());

--- a/src/lib/server/inngest/functions/send-email/batch.ts
+++ b/src/lib/server/inngest/functions/send-email/batch.ts
@@ -3,8 +3,10 @@ import assert from 'node:assert/strict';
 import { NonRetriableError } from 'inngest';
 
 import {
-  DraftFinalizedBatchEmailEvent,
-  DraftFinalizedFallbackEmailEvent,
+  DraftConcludedBatchEmailEvent,
+  DraftConcludedFallbackEmailEvent,
+  DraftFinalizationBatchEmailEvent,
+  DraftFinalizationFallbackEmailEvent,
   LotteryInterventionBatchEmailEvent,
   LotteryInterventionFallbackEmailEvent,
   RoundStartedBatchEmailEvent,
@@ -41,8 +43,10 @@ type FollowupEvent =
   | ReturnType<typeof RoundSubmittedFallbackEmailEvent.create>
   | ReturnType<typeof LotteryInterventionBatchEmailEvent.create>
   | ReturnType<typeof LotteryInterventionFallbackEmailEvent.create>
-  | ReturnType<typeof DraftFinalizedBatchEmailEvent.create>
-  | ReturnType<typeof DraftFinalizedFallbackEmailEvent.create>
+  | ReturnType<typeof DraftConcludedBatchEmailEvent.create>
+  | ReturnType<typeof DraftConcludedFallbackEmailEvent.create>
+  | ReturnType<typeof DraftFinalizationBatchEmailEvent.create>
+  | ReturnType<typeof DraftFinalizationFallbackEmailEvent.create>
   | ReturnType<typeof UserAssignedBatchEmailEvent.create>
   | ReturnType<typeof UserAssignedFallbackEmailEvent.create>;
 
@@ -55,7 +59,8 @@ export const sendBatchedEmails = inngest.createFunction(
       RoundStartedBatchEmailEvent,
       RoundSubmittedBatchEmailEvent,
       LotteryInterventionBatchEmailEvent,
-      DraftFinalizedBatchEmailEvent,
+      DraftConcludedBatchEmailEvent,
+      DraftFinalizationBatchEmailEvent,
       UserAssignedBatchEmailEvent,
     ],
   },
@@ -71,7 +76,8 @@ export const sendBatchedEmails = inngest.createFunction(
                 case 'draft/round.started.email.batch':
                 case 'draft/round.submitted.email.batch':
                 case 'draft/lottery.intervened.email.batch':
-                case 'draft/draft.finalized.email.batch':
+                case 'draft/draft.concluded.email.batch':
+                case 'draft/draft.finalization.email.batch':
                 case 'draft/user.assigned.email.batch':
                   return [event.id, event] as const;
                 default:
@@ -163,9 +169,17 @@ export const sendBatchedEmails = inngest.createFunction(
                     ),
                   );
                   break;
-                case 'draft/draft.finalized.email.batch':
+                case 'draft/draft.concluded.email.batch':
                   followupEvents.push(
-                    DraftFinalizedBatchEmailEvent.create(
+                    DraftConcludedBatchEmailEvent.create(
+                      { ...event.data, attempt: nextAttempt },
+                      options,
+                    ),
+                  );
+                  break;
+                case 'draft/draft.finalization.email.batch':
+                  followupEvents.push(
+                    DraftFinalizationBatchEmailEvent.create(
                       { ...event.data, attempt: nextAttempt },
                       options,
                     ),
@@ -212,10 +226,17 @@ export const sendBatchedEmails = inngest.createFunction(
                   );
                   break;
                 }
-                case 'draft/draft.finalized.email.batch': {
+                case 'draft/draft.concluded.email.batch': {
                   const { attempt: _, ...data } = event.data;
                   followupEvents.push(
-                    DraftFinalizedFallbackEmailEvent.create({ id: event.id, ...data }, options),
+                    DraftConcludedFallbackEmailEvent.create({ id: event.id, ...data }, options),
+                  );
+                  break;
+                }
+                case 'draft/draft.finalization.email.batch': {
+                  const { attempt: _, ...data } = event.data;
+                  followupEvents.push(
+                    DraftFinalizationFallbackEmailEvent.create({ id: event.id, ...data }, options),
                   );
                   break;
                 }

--- a/src/lib/server/inngest/functions/send-email/draft-concluded.svelte
+++ b/src/lib/server/inngest/functions/send-email/draft-concluded.svelte
@@ -54,21 +54,19 @@
   });
 </script>
 
-<EmailLayout preview="Draft #{draftId} is finalized - View final assignments">
+<EmailLayout preview="Draft #{draftId} concluded - Finalize the draft">
   <Section>
     <Section class="p-4">
-      <Heading class="text-2xl font-bold text-foreground" as="h1">Draft Finalized</Heading>
+      <Heading class="text-2xl font-bold text-foreground" as="h1">Draft Concluded</Heading>
       <Text class="text-base">
-        Draft <strong class="text-foreground">#{draftId}</strong> has just been finalized. All registered
-        students have been assigned to their respective research labs.
+        Draft <strong class="text-foreground">#{draftId}</strong> has concluded and the lottery results
+        are ready for review. Please finalize the draft once the assignments below are approved.
       </Text>
     </Section>
     {#if groupedLotteryAssignments.length > 0}
       <Section class="px-4 pb-4">
         <Section class="mx-auto max-w-md rounded-lg bg-card p-4 text-card-foreground">
-          <Heading class="text-lg font-semibold text-foreground" as="h2">
-            Finalized Lottery Results
-          </Heading>
+          <Heading class="text-lg font-semibold text-foreground" as="h2">Lottery Results</Heading>
           {#each groupedLotteryAssignments as group (group.labId)}
             <Section class="my-3 rounded-md border border-muted px-3 py-2">
               <Text class="mb-2 text-sm font-semibold">{group.labName}</Text>
@@ -108,15 +106,15 @@
     {/if}
     <Section class="px-4 pb-4">
       <Section class="mx-auto max-w-md rounded-lg bg-secondary/30 p-4 text-secondary-foreground">
-        <Text class="text-sm">See the new roster of researchers through the lab module.</Text>
+        <Text class="text-sm">Review the lottery results and finalize the draft in DRAP.</Text>
         <Button
-          href="{ORIGIN}/dashboard/"
+          href="{ORIGIN}/dashboard/drafts/{draftId}/"
           target="_blank"
           pX={24}
           pY={12}
           class="mb-4 rounded-md bg-primary font-medium text-primary-foreground hover:bg-primary/90"
         >
-          Go to Dashboard
+          Review Draft
         </Button>
       </Section>
     </Section>

--- a/src/lib/server/inngest/functions/send-email/draft-finalization.svelte
+++ b/src/lib/server/inngest/functions/send-email/draft-finalization.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import { Button, Heading, Section, Text } from '@better-svelte-email/components';
+
+  import { ORIGIN } from '$lib/env';
+
+  import EmailLayout from './email-layout.svelte';
+
+  interface Props {
+    draftId: number;
+  }
+
+  const { draftId }: Props = $props();
+</script>
+
+<EmailLayout preview="Draft #{draftId} finalized">
+  <Section>
+    <Section class="p-4">
+      <Heading class="text-2xl font-bold text-foreground" as="h1">Draft Finalization</Heading>
+      <Text class="text-base">
+        Draft <strong class="text-foreground">#{draftId}</strong> has been finalized. Assignments have
+        been synced.
+      </Text>
+    </Section>
+    <Section class="px-4 pb-4">
+      <Section class="mx-auto max-w-md rounded-lg bg-secondary/30 p-4 text-secondary-foreground">
+        <Text class="text-sm">Review the finalized draft in DRAP.</Text>
+        <Button
+          href="{ORIGIN}/dashboard/drafts/{draftId}/"
+          target="_blank"
+          pX={24}
+          pY={12}
+          class="mb-4 rounded-md bg-primary font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          View Draft
+        </Button>
+      </Section>
+    </Section>
+  </Section>
+</EmailLayout>

--- a/src/lib/server/inngest/functions/send-email/draft-finalization.svelte
+++ b/src/lib/server/inngest/functions/send-email/draft-finalization.svelte
@@ -15,7 +15,7 @@
 <EmailLayout preview="Draft #{draftId} finalized">
   <Section>
     <Section class="p-4">
-      <Heading class="text-2xl font-bold text-foreground" as="h1">Draft Finalization</Heading>
+      <Heading class="text-2xl font-bold text-foreground" as="h1">Draft Finalized</Heading>
       <Text class="text-base">
         Draft <strong class="text-foreground">#{draftId}</strong> has been finalized. Assignments have
         been synced.

--- a/src/lib/server/inngest/functions/send-email/fallback.js
+++ b/src/lib/server/inngest/functions/send-email/fallback.js
@@ -1,7 +1,8 @@
 import { NonRetriableError } from 'inngest';
 
 import {
-  DraftFinalizedFallbackEmailEvent,
+  DraftConcludedFallbackEmailEvent,
+  DraftFinalizationFallbackEmailEvent,
   LotteryInterventionFallbackEmailEvent,
   RoundStartedFallbackEmailEvent,
   RoundSubmittedFallbackEmailEvent,
@@ -27,7 +28,8 @@ export const sendEmailFallback = inngest.createFunction(
       RoundStartedFallbackEmailEvent,
       RoundSubmittedFallbackEmailEvent,
       LotteryInterventionFallbackEmailEvent,
-      DraftFinalizedFallbackEmailEvent,
+      DraftConcludedFallbackEmailEvent,
+      DraftFinalizationFallbackEmailEvent,
       UserAssignedFallbackEmailEvent,
     ],
   },
@@ -41,7 +43,8 @@ export const sendEmailFallback = inngest.createFunction(
             case 'draft/round.started.email.fallback':
             case 'draft/round.submitted.email.fallback':
             case 'draft/lottery.intervened.email.fallback':
-            case 'draft/draft.finalized.email.fallback':
+            case 'draft/draft.concluded.email.fallback':
+            case 'draft/draft.finalization.email.fallback':
             case 'draft/user.assigned.email.fallback':
               break;
             default:

--- a/src/lib/server/inngest/functions/send-email/shared.ts
+++ b/src/lib/server/inngest/functions/send-email/shared.ts
@@ -10,8 +10,10 @@ import { assertOptional } from '$lib/server/assert';
 import { db } from '$lib/server/database';
 import { decryptSecret, encryptSecret } from '$lib/crypto';
 import type {
-  DraftFinalizedBatchEmailSchema,
-  DraftFinalizedFallbackEmailSchema,
+  DraftConcludedBatchEmailSchema,
+  DraftConcludedFallbackEmailSchema,
+  DraftFinalizationBatchEmailSchema,
+  DraftFinalizationFallbackEmailSchema,
   LotteryInterventionBatchEmailSchema,
   LotteryInterventionFallbackEmailSchema,
   RoundStartedBatchEmailSchema,
@@ -27,7 +29,8 @@ import { GoogleOAuthClient } from '$lib/server/google';
 import { Logger } from '$lib/server/telemetry/logger';
 import { Tracer } from '$lib/server/telemetry/tracer';
 
-import DraftFinalized from './draft-finalized.svelte';
+import DraftConcluded from './draft-concluded.svelte';
+import DraftFinalization from './draft-finalization.svelte';
 import LotteryIntervened from './lottery-intervened.svelte';
 import RoundStarted from './round-started.svelte';
 import RoundSubmitted from './round-submitted.svelte';
@@ -49,8 +52,16 @@ type RenderableEmailEvent =
       name: 'draft/lottery.intervened.email.fallback';
       data: LotteryInterventionFallbackEmailSchema;
     }
-  | { name: 'draft/draft.finalized.email.batch'; data: DraftFinalizedBatchEmailSchema }
-  | { name: 'draft/draft.finalized.email.fallback'; data: DraftFinalizedFallbackEmailSchema }
+  | { name: 'draft/draft.concluded.email.batch'; data: DraftConcludedBatchEmailSchema }
+  | { name: 'draft/draft.concluded.email.fallback'; data: DraftConcludedFallbackEmailSchema }
+  | {
+      name: 'draft/draft.finalization.email.batch';
+      data: DraftFinalizationBatchEmailSchema;
+    }
+  | {
+      name: 'draft/draft.finalization.email.fallback';
+      data: DraftFinalizationFallbackEmailSchema;
+    }
   | { name: 'draft/user.assigned.email.batch'; data: UserAssignedBatchEmailSchema }
   | { name: 'draft/user.assigned.email.fallback'; data: UserAssignedFallbackEmailSchema };
 
@@ -103,15 +114,25 @@ export async function createEmailMessage(event: RenderableEmailEvent, sender: Se
         } satisfies ComponentProps<typeof LotteryIntervened>,
       });
       break;
-    case 'draft/draft.finalized.email.batch':
-    case 'draft/draft.finalized.email.fallback':
+    case 'draft/draft.concluded.email.batch':
+    case 'draft/draft.concluded.email.fallback':
       recipient = event.data.recipientEmail;
-      subject = `[DRAP] Draft #${event.data.draftId} Finalized`;
-      html = await emailRenderer.render(DraftFinalized, {
+      subject = `[DRAP] Draft #${event.data.draftId} Concluded`;
+      html = await emailRenderer.render(DraftConcluded, {
         props: {
           draftId: event.data.draftId,
           lotteryAssignments: event.data.lotteryAssignments,
-        } satisfies ComponentProps<typeof DraftFinalized>,
+        } satisfies ComponentProps<typeof DraftConcluded>,
+      });
+      break;
+    case 'draft/draft.finalization.email.batch':
+    case 'draft/draft.finalization.email.fallback':
+      recipient = event.data.recipientEmail;
+      subject = `[DRAP] Draft #${event.data.draftId} Finalized`;
+      html = await emailRenderer.render(DraftFinalization, {
+        props: {
+          draftId: event.data.draftId,
+        } satisfies ComponentProps<typeof DraftFinalization>,
       });
       break;
     case 'draft/user.assigned.email.batch':

--- a/src/lib/server/inngest/schema.ts
+++ b/src/lib/server/inngest/schema.ts
@@ -97,7 +97,7 @@ export type LotteryInterventionFallbackEmailSchema = v.InferOutput<
   typeof LotteryInterventionFallbackEmailEvent.schema
 >;
 
-export const DraftFinalizedBatchEmailEvent = eventType('draft/draft.finalized.email.batch', {
+export const DraftConcludedBatchEmailEvent = eventType('draft/draft.concluded.email.batch', {
   schema: v.object({
     draftId: v.number(),
     recipientEmail: v.string(),
@@ -114,11 +114,11 @@ export const DraftFinalizedBatchEmailEvent = eventType('draft/draft.finalized.em
     attempt: EmailAttempt,
   }),
 });
-export type DraftFinalizedBatchEmailSchema = v.InferOutput<
-  typeof DraftFinalizedBatchEmailEvent.schema
+export type DraftConcludedBatchEmailSchema = v.InferOutput<
+  typeof DraftConcludedBatchEmailEvent.schema
 >;
 
-export const DraftFinalizedFallbackEmailEvent = eventType('draft/draft.finalized.email.fallback', {
+export const DraftConcludedFallbackEmailEvent = eventType('draft/draft.concluded.email.fallback', {
   schema: v.object({
     id: v.string(),
     draftId: v.number(),
@@ -135,8 +135,35 @@ export const DraftFinalizedFallbackEmailEvent = eventType('draft/draft.finalized
     ),
   }),
 });
-export type DraftFinalizedFallbackEmailSchema = v.InferOutput<
-  typeof DraftFinalizedFallbackEmailEvent.schema
+export type DraftConcludedFallbackEmailSchema = v.InferOutput<
+  typeof DraftConcludedFallbackEmailEvent.schema
+>;
+
+export const DraftFinalizationBatchEmailEvent = eventType('draft/draft.finalization.email.batch', {
+  schema: v.object({
+    draftId: v.number(),
+    recipientEmail: v.string(),
+    recipientName: v.string(),
+    attempt: EmailAttempt,
+  }),
+});
+export type DraftFinalizationBatchEmailSchema = v.InferOutput<
+  typeof DraftFinalizationBatchEmailEvent.schema
+>;
+
+export const DraftFinalizationFallbackEmailEvent = eventType(
+  'draft/draft.finalization.email.fallback',
+  {
+    schema: v.object({
+      id: v.string(),
+      draftId: v.number(),
+      recipientEmail: v.string(),
+      recipientName: v.string(),
+    }),
+  },
+);
+export type DraftFinalizationFallbackEmailSchema = v.InferOutput<
+  typeof DraftFinalizationFallbackEmailEvent.schema
 >;
 
 export const UserAssignedBatchEmailEvent = eventType('draft/user.assigned.email.batch', {

--- a/src/routes/(landing)/+page.svelte
+++ b/src/routes/(landing)/+page.svelte
@@ -140,7 +140,7 @@
             <span>For Students</span>
           </span>
         </Accordion.Trigger>
-        <Accordion.Content class="prose px-4 dark:prose-invert">
+        <Accordion.Content class="prose max-w-none px-4 dark:prose-invert">
           <ol>
             <li>
               Go to your <Link href={resolve('/dashboard/')}>profile</Link> and set your student number.
@@ -166,7 +166,7 @@
             <span>For Lab Heads</span>
           </span>
         </Accordion.Trigger>
-        <Accordion.Content class="prose px-4 dark:prose-invert">
+        <Accordion.Content class="prose max-w-none px-4 dark:prose-invert">
           <ol>
             <li>Wait for the administrators to open a draft.</li>
             <li>
@@ -198,7 +198,7 @@
             <span>For Administrators</span>
           </span>
         </Accordion.Trigger>
-        <Accordion.Content class="prose px-4 dark:prose-invert">
+        <Accordion.Content class="prose max-w-none px-4 dark:prose-invert">
           <ol>
             <li>Maintain the <Link href={resolve('/dashboard/labs/')}>lab catalog</Link>.</li>
             <li>Initialize a <Link href={resolve('/dashboard/drafts/')}>new draft</Link>.</li>

--- a/src/routes/dashboard/(draft)/drafts/[draftId]/+page.server.ts
+++ b/src/routes/dashboard/(draft)/drafts/[draftId]/+page.server.ts
@@ -13,6 +13,7 @@ import {
   autoAcknowledgeLabsWithoutPreferences,
   type DbConnection,
   type DrizzleTransaction,
+  getDraftAdmins,
   getDraftAssignmentRecords,
   getDraftById,
   getDraftByIdForUpdate,
@@ -26,7 +27,8 @@ import {
 import { coerceDate, coerceNullableNumber, coerceNumber } from '$lib/coerce';
 import { db } from '$lib/server/database';
 import {
-  DraftFinalizedBatchEmailEvent,
+  DraftConcludedBatchEmailEvent,
+  DraftFinalizationBatchEmailEvent,
   LotteryInterventionBatchEmailEvent,
   RoundStartedBatchEmailEvent,
   UserAssignedBatchEmailEvent,
@@ -692,6 +694,32 @@ export const actions = {
         }
         throw err;
       }
+
+      const [draftAdmins, assignments] = await Promise.all([
+        getDraftAdmins(db),
+        getDraftAssignmentRecords(db, draftId),
+      ]);
+
+      const lotteryAssignments = assignments
+        .filter(({ round }) => round === null)
+        .map(({ labId, labName, givenName, familyName, email, avatarUrl }) => ({
+          labId,
+          labName,
+          studentName: `${givenName} ${familyName}`,
+          studentEmail: email,
+          avatarUrl,
+        }));
+
+      await inngest.send(
+        draftAdmins.map(({ email, givenName, familyName }) =>
+          DraftConcludedBatchEmailEvent.create({
+            draftId: Number(draftId),
+            recipientEmail: email,
+            recipientName: `${givenName} ${familyName}`,
+            lotteryAssignments,
+          }),
+        ),
+      );
     });
   },
 
@@ -759,28 +787,13 @@ export const actions = {
         { isolationLevel: 'read committed' },
       );
 
-      const [facultyAndStaff, assignments] = await Promise.all([
-        getDraftNotificationRecipients(db, draftId),
-        getDraftAssignmentRecords(db, draftId),
-      ]);
-
-      const lotteryAssignments = assignments
-        .filter(({ round }) => round === null)
-        .map(({ labId, labName, givenName, familyName, email, avatarUrl }) => ({
-          labId,
-          labName,
-          studentName: `${givenName} ${familyName}`,
-          studentEmail: email,
-          avatarUrl,
-        }));
-
+      const draftAdmins = await getDraftAdmins(db);
       await inngest.send(
-        facultyAndStaff.map(({ email, givenName, familyName }) =>
-          DraftFinalizedBatchEmailEvent.create({
+        draftAdmins.map(({ email, givenName, familyName }) =>
+          DraftFinalizationBatchEmailEvent.create({
             draftId: Number(draftId),
             recipientEmail: email,
             recipientName: `${givenName} ${familyName}`,
-            lotteryAssignments,
           }),
         ),
       );

--- a/src/routes/dashboard/(draft)/drafts/[draftId]/+page.server.ts
+++ b/src/routes/dashboard/(draft)/drafts/[draftId]/+page.server.ts
@@ -787,9 +787,9 @@ export const actions = {
         { isolationLevel: 'read committed' },
       );
 
-      const draftAdmins = await getDraftAdmins(db);
+      const facultyAndStaff = await getDraftNotificationRecipients(db, draftId);
       await inngest.send(
-        draftAdmins.map(({ email, givenName, familyName }) =>
+        facultyAndStaff.map(({ email, givenName, familyName }) =>
           DraftFinalizationBatchEmailEvent.create({
             draftId: Number(draftId),
             recipientEmail: email,

--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -18,8 +18,9 @@ import {
 } from '$lib/server/database/drizzle';
 import { dev } from '$app/environment';
 import {
-  DraftFinalizedBatchEmailEvent,
-  type DraftFinalizedBatchEmailSchema,
+  DraftConcludedBatchEmailEvent,
+  type DraftConcludedBatchEmailSchema,
+  DraftFinalizationBatchEmailEvent,
   LotteryInterventionBatchEmailEvent,
   RoundStartedBatchEmailEvent,
   RoundSubmittedBatchEmailEvent,
@@ -100,10 +101,15 @@ const SendEmailFormData = v.variant('event', [
     recipientEmail: v.string(),
   }),
   v.object({
-    event: v.literal('draft/draft.finalized.email.batch'),
+    event: v.literal('draft/draft.concluded.email.batch'),
     draftId: v.number(),
     recipientEmail: v.string(),
     lotteryAssignments: v.optional(v.array(LotteryAssignmentFormData), []),
+  }),
+  v.object({
+    event: v.literal('draft/draft.finalization.email.batch'),
+    draftId: v.number(),
+    recipientEmail: v.string(),
   }),
   v.object({
     event: v.literal('draft/user.assigned.email.batch'),
@@ -408,7 +414,7 @@ export const actions = {
                 );
                 break;
               }
-              case 'draft/draft.finalized.email.batch': {
+              case 'draft/draft.concluded.email.batch': {
                 let givenName: string;
                 let familyName: string;
 
@@ -422,7 +428,7 @@ export const actions = {
                   throw err;
                 }
 
-                const lotteryAssignments: DraftFinalizedBatchEmailSchema['lotteryAssignments'] = [];
+                const lotteryAssignments: DraftConcludedBatchEmailSchema['lotteryAssignments'] = [];
                 for (const { labId, studentEmail } of parsed.lotteryAssignments) {
                   let labName: string;
                   try {
@@ -469,11 +475,33 @@ export const actions = {
                 }
 
                 await inngest.send(
-                  DraftFinalizedBatchEmailEvent.create({
+                  DraftConcludedBatchEmailEvent.create({
                     draftId: parsed.draftId,
                     recipientEmail: parsed.recipientEmail,
                     recipientName: `${givenName} ${familyName}`,
                     lotteryAssignments,
+                  }),
+                );
+                break;
+              }
+              case 'draft/draft.finalization.email.batch': {
+                let givenName: string;
+                let familyName: string;
+
+                try {
+                  ({ givenName, familyName } = await getUserNameByEmail(db, parsed.recipientEmail));
+                } catch (err) {
+                  if (err instanceof AssertionError) {
+                    logger.fatal('unknown recipient email', err);
+                    return fail(404, { message: 'Recipient email is not a user in the database.' });
+                  }
+                  throw err;
+                }
+                await inngest.send(
+                  DraftFinalizationBatchEmailEvent.create({
+                    draftId: parsed.draftId,
+                    recipientEmail: parsed.recipientEmail,
+                    recipientName: `${givenName} ${familyName}`,
                   }),
                 );
                 break;

--- a/src/routes/dashboard/lab/+page.server.ts
+++ b/src/routes/dashboard/lab/+page.server.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, isNotNull, isNull } from 'drizzle-orm';
+import { and, asc, desc, eq, isNotNull, isNull, sql } from 'drizzle-orm';
 import { error, redirect } from '@sveltejs/kit';
 
 import * as schema from '$lib/server/database/schema';
@@ -119,7 +119,13 @@ async function getLabMembers(db: DbConnection, labId: string, draftId?: bigint) 
               avatarUrl: schema.labMemberView.avatarUrl,
             })
             .from(schema.labMemberView)
-            .where(eq(schema.labMemberView.draftLab, labId))
+            .innerJoin(schema.draft, eq(schema.labMemberView.draftId, schema.draft.id))
+            .where(
+              and(
+                eq(schema.labMemberView.draftLab, labId),
+                isNotNull(sql`upper(${schema.draft.activePeriod})`),
+              ),
+            )
             .orderBy(({ draftId, familyName }) => [asc(draftId), asc(familyName)])
         : db
             .select({
@@ -130,10 +136,12 @@ async function getLabMembers(db: DbConnection, labId: string, draftId?: bigint) 
               avatarUrl: schema.labMemberView.avatarUrl,
             })
             .from(schema.labMemberView)
+            .innerJoin(schema.draft, eq(schema.labMemberView.draftId, schema.draft.id))
             .where(
               and(
                 eq(schema.labMemberView.draftLab, labId),
                 eq(schema.labMemberView.draftId, draftId),
+                isNotNull(sql`upper(${schema.draft.activePeriod})`),
               ),
             )
             .orderBy(({ draftId, familyName }) => [asc(draftId), asc(familyName)]);
@@ -147,7 +155,14 @@ async function getUserLabAssignmentDraftId(db: DbConnection, userId: string, lab
     return await db
       .select({ draftId: schema.labMemberView.draftId })
       .from(schema.labMemberView)
-      .where(and(eq(schema.labMemberView.userId, userId), eq(schema.labMemberView.draftLab, labId)))
+      .innerJoin(schema.draft, eq(schema.labMemberView.draftId, schema.draft.id))
+      .where(
+        and(
+          eq(schema.labMemberView.userId, userId),
+          eq(schema.labMemberView.draftLab, labId),
+          isNotNull(sql`upper(${schema.draft.activePeriod})`),
+        ),
+      )
       .orderBy(desc(schema.labMemberView.draftId))
       .then(assertOptional);
   });


### PR DESCRIPTION
This resolves #275 by fixing the draft conclusion/finalization email lifecycle so admins are notified at the correct moments. The lottery-results email now belongs to draft conclusion, is titled "Draft Concluded", and asks draft admins to "finalize the draft" after reviewing the results. Finalization now sends a separate confirmation email to central draft admins and participating lab heads after assignments are synced.

This also closes a pre-finalization visibility gap in the lab dashboard: lab heads no longer see concluded draft results through the lab member view until the draft has been finalized and committed.

## Implementation Notes

### Draft Conclusion Email Flow

- Renamed the previous draft-finalized lottery-results event path into the draft-concluded event path:
  - `draft/draft.concluded.email.batch`
  - `draft/draft.concluded.email.fallback`
- Moved the lottery-results email dispatch from `finalize` to `conclude`.
- Added central draft admin recipient lookup for registered admins only:
  - `isAdmin = true`
  - `googleUserId IS NOT NULL`
  - `labId IS NULL`
- Updated the email renderer, batch retry path, fallback path, schema definitions, and dev email dispatcher to recognize the concluded event.

### Draft Finalization Email Flow

- Added a separate finalization confirmation email using:
  - `draft/draft.finalization.email.batch`
  - `draft/draft.finalization.email.fallback`
- Finalization now sends the confirmation email to central draft admins and participating lab heads after the draft closes.
- Existing student assignment notifications are preserved through `draft/user.assigned.email.batch`.

### Lab Result Visibility

- The lab dashboard now joins draft metadata when reading `lab_member_view`.
- Lab member rows are only shown when the draft has a committed upper active-period bound, which keeps concluded-but-unfinalized lottery results hidden from lab heads.
- The underlying view remains unchanged so existing historical assignment queries keep their current semantics outside this route.

### Other Branch Changes

- Adjusted dev email dispatcher options for the new event names.
- Removed opacity from the dev tools button hover state.
- Removed the landing-page accordion `prose` max-width cap so instructions use the available accordion width.

## Test Cases

- [ ] Concluding a draft sends `draft/draft.concluded.email.batch` to central draft admins with lottery results and "finalize the draft" copy.
- [ ] Finalizing a draft sends `draft/draft.finalization.email.batch` to central draft admins and participating lab heads with the finalized/synced confirmation.
- [ ] Finalizing a draft still sends `draft/user.assigned.email.batch` to assigned students.
- [ ] Finalizing a draft no longer sends the concluded lottery-results email.
- [ ] A lab head cannot see concluded draft assignment results before finalization.
- [ ] A lab head can see committed lab assignment results after finalization.
