### PR TITLE
refactor(ui): scope responsive layouts with container queries

### DIFF
--- a/src/lib/components/hero.svelte
+++ b/src/lib/components/hero.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <div
-  class="not-prose m-6 flex min-h-104 flex-col items-center justify-center rounded-2xl bg-[rgb(30,79,65)] bg-dcs bg-cover bg-center p-6 text-center bg-blend-multiply shadow-md shadow-black/30 dark:shadow-inner"
+  class="not-prose flex min-h-104 flex-col items-center justify-center rounded-2xl bg-[rgb(30,79,65)] bg-dcs bg-cover bg-center p-6 text-center bg-blend-multiply shadow-md shadow-black/30 dark:shadow-inner"
 >
   <img src={Logo} alt="Logo of DRAP" class="w-4/5 max-w-136 md:-mb-8" />
   <div>

--- a/src/lib/components/ui/empty/empty-media.svelte
+++ b/src/lib/components/ui/empty/empty-media.svelte
@@ -2,7 +2,7 @@
   import { tv, type VariantProps } from 'tailwind-variants';
 
   export const emptyMediaVariants = tv({
-    base: 'mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0',
+    base: 'flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0',
     variants: {
       variant: {
         default: '',

--- a/src/lib/features/contributors/index.svelte
+++ b/src/lib/features/contributors/index.svelte
@@ -100,7 +100,7 @@
   }
 </script>
 
-<Tabs.Root value="all">
+<Tabs.Root value="all" class="@container">
   <Tabs.List class="w-full">
     <Tabs.Trigger value="all">All</Tabs.Trigger>
     {#each CONTRIBUTOR_YEARS as year (year)}
@@ -108,7 +108,7 @@
     {/each}
   </Tabs.List>
   <Tabs.Content value="all">
-    <div class="grid grid-cols-2 gap-2 md:grid-cols-4">
+    <div class="grid grid-cols-2 gap-2 @xl:grid-cols-4">
       {#each CONTRIBUTORS as { name, avatar, website, github } (name)}
         <ContributorCard {name} {avatar} {website} {github} />
       {/each}
@@ -117,7 +117,7 @@
   {#each CONTRIBUTOR_YEARS as year (year)}
     {@const contributors = getContributorsByYear(year)}
     <Tabs.Content value={year}>
-      <div class="grid grid-cols-2 gap-2 md:grid-cols-4">
+      <div class="grid grid-cols-2 gap-2 @xl:grid-cols-4">
         {#each contributors as { name, role, avatar, website, github } (name)}
           <ContributorCard {name} {role} {avatar} {website} {github} />
         {/each}

--- a/src/lib/features/contributors/index.svelte
+++ b/src/lib/features/contributors/index.svelte
@@ -100,7 +100,7 @@
   }
 </script>
 
-<Tabs.Root value="all" class="mt-6">
+<Tabs.Root value="all">
   <Tabs.List class="w-full">
     <Tabs.Trigger value="all">All</Tabs.Trigger>
     {#each CONTRIBUTOR_YEARS as year (year)}

--- a/src/lib/features/drafts/assignments/display.svelte
+++ b/src/lib/features/drafts/assignments/display.svelte
@@ -14,9 +14,9 @@
   const { regularDrafted, interventionDrafted, lotteryDrafted }: Props = $props();
 </script>
 
-<div class="grid grid-cols-1 gap-2">
-  <div id="section-regular-drafted" class="mb-8">
-    <h3 class="mb-4 text-2xl font-bold">Regular Drafted ({regularDrafted.length})</h3>
+<div class="flex flex-col gap-8">
+  <div id="section-regular-drafted" class="grid gap-4">
+    <h3 class="text-2xl font-bold">Regular Drafted ({regularDrafted.length})</h3>
     <div class="space-y-2">
       {#each regularDrafted as { id, email, givenName, familyName, studentNumber, labId, round } (id)}
         <div class="flex items-center justify-between space-y-1">
@@ -44,8 +44,8 @@
     </div>
   </div>
 
-  <div id="section-intervention-drafted" class="mb-8">
-    <h3 class="mb-4 text-2xl font-bold">Intervention Drafted ({interventionDrafted.length})</h3>
+  <div id="section-intervention-drafted" class="grid gap-4">
+    <h3 class="text-2xl font-bold">Intervention Drafted ({interventionDrafted.length})</h3>
     <div class="space-y-2">
       {#each interventionDrafted as { id, email, givenName, familyName, studentNumber, labId, assignedAt } (id)}
         <div class="flex items-center justify-between space-y-1">
@@ -78,8 +78,8 @@
       {/each}
     </div>
   </div>
-  <div id="section-lottery-drafted" class="mb-8">
-    <h3 class="mb-4 text-2xl font-bold">Lottery Drafted ({lotteryDrafted.length})</h3>
+  <div id="section-lottery-drafted" class="grid gap-4">
+    <h3 class="text-2xl font-bold">Lottery Drafted ({lotteryDrafted.length})</h3>
     <div class="space-y-2">
       {#each lotteryDrafted as { id, email, givenName, familyName, studentNumber, labId } (id)}
         <div class="flex items-center justify-between space-y-1">

--- a/src/lib/features/drafts/timeline/interventions/quota-dumbbell-chart.svelte
+++ b/src/lib/features/drafts/timeline/interventions/quota-dumbbell-chart.svelte
@@ -68,10 +68,10 @@
 </script>
 
 <Card.Root
-  class="overflow-hidden border-border/60 bg-linear-to-br from-muted/40 via-background to-muted/10 shadow-xs"
+  class="@container overflow-hidden border-border/60 bg-linear-to-br from-muted/40 via-background to-muted/10 shadow-xs"
 >
   <Card.Header class="gap-3">
-    <div class="flex flex-wrap items-center justify-between gap-2 sm:items-start">
+    <div class="flex flex-wrap items-center justify-between gap-2 @lg:items-start">
       <div class="space-y-1">
         <Card.Title class="flex items-center gap-1.5">
           <span>Regular-Round Vacancies vs. Lottery Quota</span>
@@ -128,7 +128,7 @@
           Regular-round vacancies compared with final lottery quota.
         </Card.Description>
       </div>
-      <div class="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:gap-2">
+      <div class="flex w-full flex-col gap-2 @lg:w-auto @lg:flex-row @lg:gap-2">
         {#if !isHistorical}
           <EditLotteryQuota {draftId} {snapshots} />
           <EligibleStudentsSheet {draftId} {labs} />

--- a/src/lib/features/drafts/timeline/interventions/stat-cards.svelte
+++ b/src/lib/features/drafts/timeline/interventions/stat-cards.svelte
@@ -4,6 +4,7 @@
   import ScaleIcon from '@lucide/svelte/icons/scale';
 
   import StatCard from '$lib/features/drafts/timeline/stat-card.svelte';
+  import StatCardGroup from '$lib/features/drafts/timeline/stat-card-group.svelte';
   import { cn } from '$lib/components/ui/utils';
   import type { InterventionsStatCards } from '$lib/features/drafts/types';
 
@@ -17,7 +18,7 @@
   const deltaWarning = $derived(!isHistorical && data.delta !== 0);
 </script>
 
-<div class="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+<StatCardGroup columns="five">
   <StatCard icon={LayersIcon}>
     {#snippet title()}Pool Size{/snippet}
     {#snippet body()}
@@ -54,4 +55,4 @@
       {/snippet}
     </StatCard>
   {/if}
-</div>
+</StatCardGroup>

--- a/src/lib/features/drafts/timeline/lottery/outcome/index.svelte
+++ b/src/lib/features/drafts/timeline/lottery/outcome/index.svelte
@@ -90,17 +90,17 @@
 </script>
 
 <Card.Root
-  class="overflow-hidden border-border/60 bg-linear-to-br from-muted/40 via-background to-muted/10 shadow-xs"
+  class="@container overflow-hidden border-border/60 bg-linear-to-br from-muted/40 via-background to-muted/10 shadow-xs"
 >
   <Card.Header class="gap-3">
-    <div class="flex flex-wrap items-center justify-between gap-2 sm:items-start">
+    <div class="flex flex-wrap items-center justify-between gap-2 @lg:items-start">
       <div class="space-y-1">
         <Card.Title>Per-Lab Lottery Outcome</Card.Title>
         <Card.Description>
           Lottery-placed students by lab, broken down by preference rank quality
         </Card.Description>
       </div>
-      <div class="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:gap-2">
+      <div class="flex w-full flex-col gap-2 @lg:w-auto @lg:flex-row @lg:gap-2">
         <LotteryResultsSheet {draftId} />
       </div>
     </div>

--- a/src/lib/features/drafts/timeline/lottery/stat-cards.svelte
+++ b/src/lib/features/drafts/timeline/lottery/stat-cards.svelte
@@ -6,6 +6,7 @@
   import ThumbsUpIcon from '@lucide/svelte/icons/thumbs-up';
 
   import StatCard from '$lib/features/drafts/timeline/stat-card.svelte';
+  import StatCardGroup from '$lib/features/drafts/timeline/stat-card-group.svelte';
   import type { LotteryStatCards } from '$lib/features/drafts/types';
 
   interface Props {
@@ -19,7 +20,7 @@
   );
 </script>
 
-<div class="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+<StatCardGroup columns="five">
   <StatCard icon={LayersIcon}>
     {#snippet title()}Pool Size{/snippet}
     {#snippet body()}
@@ -59,4 +60,4 @@
     {/snippet}
     {#snippet subtitle()}Among Ranked Placements{/snippet}
   </StatCard>
-</div>
+</StatCardGroup>

--- a/src/lib/features/drafts/timeline/registration/active.svelte
+++ b/src/lib/features/drafts/timeline/registration/active.svelte
@@ -5,6 +5,7 @@
   import * as Alert from '$lib/components/ui/alert';
   import QuotaCard from '$lib/features/drafts/timeline/quota-card.svelte';
   import StatCard from '$lib/features/drafts/timeline/stat-card.svelte';
+  import StatCardGroup from '$lib/features/drafts/timeline/stat-card-group.svelte';
   import type { DraftLabQuotaSnapshot } from '$lib/features/drafts/types';
 
   interface Props {
@@ -18,7 +19,7 @@
 
 <div class="space-y-4">
   {#if studentCount > 0}
-    <div class="grid w-fit grid-cols-1 gap-2 sm:grid-cols-[repeat(1,minmax(10rem,14rem))]">
+    <StatCardGroup columns="one">
       <StatCard icon={UsersIcon}>
         {#snippet title()}Registered Students{/snippet}
         {#snippet body()}
@@ -28,7 +29,7 @@
         {/snippet}
         {#snippet subtitle()}Current Draft Participants{/snippet}
       </StatCard>
-    </div>
+    </StatCardGroup>
   {:else}
     <Alert.Root variant="warning">
       <TriangleAlertIcon />

--- a/src/lib/features/drafts/timeline/registration/closed.svelte
+++ b/src/lib/features/drafts/timeline/registration/closed.svelte
@@ -6,6 +6,7 @@
   import * as Alert from '$lib/components/ui/alert';
   import QuotaCard from '$lib/features/drafts/timeline/quota-card.svelte';
   import StatCard from '$lib/features/drafts/timeline/stat-card.svelte';
+  import StatCardGroup from '$lib/features/drafts/timeline/stat-card-group.svelte';
   import type { DraftLabQuotaSnapshot } from '$lib/features/drafts/types';
 
   import { AllowlistSheet } from './allowlist-sheet';
@@ -22,7 +23,7 @@
 
 <div class="space-y-4">
   {#if studentCount > 0}
-    <div class="grid w-fit grid-cols-1 gap-2 sm:grid-cols-[repeat(2,minmax(10rem,14rem))]">
+    <StatCardGroup columns="two">
       <StatCard icon={UsersIcon}>
         {#snippet title()}Registered Students{/snippet}
         {#snippet body()}
@@ -41,7 +42,7 @@
         {/snippet}
         {#snippet subtitle()}Late Registration Access{/snippet}
       </StatCard>
-    </div>
+    </StatCardGroup>
   {:else}
     <Alert.Root variant="info">
       <LockIcon />

--- a/src/lib/features/drafts/timeline/registration/completed.svelte
+++ b/src/lib/features/drafts/timeline/registration/completed.svelte
@@ -2,6 +2,7 @@
   import UsersIcon from '@lucide/svelte/icons/users';
 
   import StatCard from '$lib/features/drafts/timeline/stat-card.svelte';
+  import StatCardGroup from '$lib/features/drafts/timeline/stat-card-group.svelte';
 
   import RegistrantsChart from './registrants-chart.svelte';
 
@@ -35,7 +36,7 @@
 </script>
 
 <div class="space-y-4">
-  <div class="grid w-fit grid-cols-1 gap-2 sm:grid-cols-[repeat(1,minmax(10rem,14rem))]">
+  <StatCardGroup columns="one">
     <StatCard icon={UsersIcon}>
       {#snippet title()}Registered Students{/snippet}
       {#snippet body()}
@@ -51,7 +52,7 @@
         {/if}
       {/snippet}
     </StatCard>
-  </div>
+  </StatCardGroup>
   <RegistrantsChart
     {draftId}
     {draftCreatedAt}

--- a/src/lib/features/drafts/timeline/registration/registrants-chart.svelte
+++ b/src/lib/features/drafts/timeline/registration/registrants-chart.svelte
@@ -91,18 +91,18 @@
 </script>
 
 <Card.Root
-  class="overflow-hidden border-border/60 bg-linear-to-br from-muted/40 via-background to-muted/10 shadow-xs"
+  class="@container overflow-hidden border-border/60 bg-linear-to-br from-muted/40 via-background to-muted/10 shadow-xs"
 >
   <Card.Header class="gap-5">
-    <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-      <div class="space-y-1.5 lg:flex-1">
+    <div class="flex flex-col gap-4 @5xl:flex-row @5xl:items-start @5xl:justify-between">
+      <div class="space-y-1.5 @5xl:flex-1">
         <div class="flex flex-wrap items-center gap-2">
           <Card.Title>Registrants per Day</Card.Title>
           <Badge variant="default">Draft Creation to Start</Badge>
         </div>
         <Card.Description>Shows how many students registered each day</Card.Description>
       </div>
-      <div class="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:gap-2">
+      <div class="flex w-full flex-col gap-2 @lg:w-auto @lg:flex-row @lg:gap-2">
         <DrafteesSheet {draftId} />
       </div>
     </div>

--- a/src/lib/features/drafts/timeline/stat-card-group.svelte
+++ b/src/lib/features/drafts/timeline/stat-card-group.svelte
@@ -1,0 +1,34 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+  import { tv, type VariantProps } from 'tailwind-variants';
+
+  import { cn } from '$lib/components/ui/utils';
+
+  export const statCardGroupVariants = tv({
+    base: 'grid w-full grid-cols-1 gap-2',
+    variants: {
+      columns: {
+        one: '@lg:w-fit @lg:grid-cols-[repeat(1,minmax(10rem,14rem))]',
+        two: '@lg:w-fit @lg:grid-cols-[repeat(2,minmax(10rem,14rem))]',
+        five: '@lg:grid-cols-2 @5xl:grid-cols-3 @7xl:grid-cols-5',
+      },
+    },
+  });
+
+  export type StatCardGroupColumns = VariantProps<typeof statCardGroupVariants>['columns'];
+  interface Props {
+    children: Snippet;
+    columns: StatCardGroupColumns;
+    class?: string;
+  }
+</script>
+
+<script lang="ts">
+  const { children, columns, class: className }: Props = $props();
+</script>
+
+<div class="@container">
+  <div class={cn(statCardGroupVariants({ columns }), className)}>
+    {@render children()}
+  </div>
+</div>

--- a/src/lib/features/drafts/timeline/summary/draft-rounds-chart.svelte
+++ b/src/lib/features/drafts/timeline/summary/draft-rounds-chart.svelte
@@ -89,21 +89,21 @@
 </script>
 
 <Card.Root
-  class="overflow-hidden border-border/60 bg-linear-to-br from-muted/40 via-background to-muted/10 shadow-xs"
+  class="@container overflow-hidden border-border/60 bg-linear-to-br from-muted/40 via-background to-muted/10 shadow-xs"
 >
   <Card.Header class="gap-5">
-    <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-      <div class="space-y-1.5 lg:grow">
+    <div class="flex flex-col gap-4 @5xl:flex-row @5xl:items-start @5xl:justify-between">
+      <div class="space-y-1.5 @5xl:grow">
         <Card.Title id="draft-rounds-chart-title">{chartTitle} per Phase</Card.Title>
         <Card.Description>
           Visualizes student assignments or remaining lab quota across draft phases.
         </Card.Description>
       </div>
-      <div class="flex flex-col gap-2 sm:flex-row lg:shrink-0 lg:justify-end">
+      <div class="flex flex-col gap-2 @lg:flex-row @5xl:shrink-0 @5xl:justify-end">
         <NativeSelect.Root
           id="draft-rounds-chart-mode"
           bind:value={chartMode}
-          class="w-full bg-background/80 sm:w-auto"
+          class="w-full bg-background/80 @lg:w-auto"
         >
           <NativeSelect.Option value="assigned">Assigned</NativeSelect.Option>
           <NativeSelect.Option value="remaining">Remaining</NativeSelect.Option>
@@ -111,7 +111,7 @@
         <NativeSelect.Root
           id="draft-rounds-chart-lab"
           bind:value={selectedLabId}
-          class="w-full bg-background/80 sm:w-auto"
+          class="w-full bg-background/80 @lg:w-auto"
         >
           <NativeSelect.Option value="">All Labs</NativeSelect.Option>
           {#each chart.labs as { id, name } (id)}

--- a/src/lib/features/drafts/timeline/summary/index.svelte
+++ b/src/lib/features/drafts/timeline/summary/index.svelte
@@ -8,6 +8,7 @@
   import DraftAssignments from '$lib/features/drafts/assignments/index.svelte';
   import LotteryCompleted from '$lib/features/drafts/timeline/lottery/completed.svelte';
   import StatCard from '$lib/features/drafts/timeline/stat-card.svelte';
+  import StatCardGroup from '$lib/features/drafts/timeline/stat-card-group.svelte';
   import type {
     Draft,
     DraftAssignmentSummary,
@@ -66,7 +67,7 @@
       </div>
     </Alert.Root>
   {/if}
-  <div class="grid w-fit grid-cols-1 gap-2 sm:grid-cols-[repeat(2,minmax(10rem,14rem))]">
+  <StatCardGroup columns="two">
     <StatCard icon={UsersIcon}>
       {#snippet title()}Total Students{/snippet}
       {#snippet body()}
@@ -83,11 +84,11 @@
       {/snippet}
       {#snippet subtitle()}Active Labs in Draft{/snippet}
     </StatCard>
-  </div>
+  </StatCardGroup>
   <div class="space-y-4">
     <DraftRoundsChart chart={assignmentSummary.chart} />
     <SupplyDemandChart data={draftSummaryChartData.supplyVsDemand} />
-    <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
+    <div class="grid grid-cols-1 gap-4 @5xl:grid-cols-2">
       <LabDistributionChart data={draftSummaryChartData.labDistribution} />
       <PreferenceAlignmentChart data={draftSummaryChartData.preferenceAlignment} />
     </div>

--- a/src/lib/features/student/registration-open/lab-preference-form.svelte
+++ b/src/lib/features/student/registration-open/lab-preference-form.svelte
@@ -112,7 +112,7 @@
   method="post"
   enctype="multipart/form-data"
   action="/dashboard/student/?/submit"
-  class="space-y-4"
+  class="@container space-y-4"
   use:enhance={({ submitter, cancel }) => {
     const message =
       persistedSelectedLabs.current.length === 0
@@ -178,7 +178,7 @@
     Select your preferred labs from the list of available labs and rank them by order of preference.
   </p>
   <AvatarConsent avatarUrl={user.avatarUrl} />
-  <div class="grid grid-cols-1 items-start gap-4 md:grid-cols-2">
+  <div class="grid grid-cols-1 items-start gap-4 @xl:grid-cols-2">
     <Card.Root variant="soft" class="flex h-full">
       <Card.Header>
         <Card.Title class="text-2xl">Available Labs</Card.Title>

--- a/src/lib/features/users/draft-admin-card/admin-row.svelte
+++ b/src/lib/features/users/draft-admin-card/admin-row.svelte
@@ -23,7 +23,7 @@
 
 <div
   class={cn(
-    'grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-3 gap-y-2 rounded-lg border-2 border-transparent p-3 transition-colors duration-150 sm:grid-cols-[auto_minmax(0,1fr)_auto]',
+    'grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-3 gap-y-2 rounded-lg border-2 border-transparent p-3 transition-colors duration-150 @lg:grid-cols-[auto_minmax(0,1fr)_auto]',
     role === 'designated' ? 'border-success/50 bg-success/20 dark:bg-success/5' : 'bg-muted',
   )}
 >
@@ -49,12 +49,12 @@
   </div>
   {#if role === 'none'}
     {#if isSelf}
-      <div class="col-span-2 justify-self-end sm:col-span-1">
+      <div class="col-span-2 justify-self-end @lg:col-span-1">
         <VolunteerButton />
       </div>
     {/if}
   {:else}
-    <div class="col-span-2 justify-self-end sm:col-span-1">
+    <div class="col-span-2 justify-self-end @lg:col-span-1">
       <AdminActions userId={user.id} {role} />
     </div>
   {/if}

--- a/src/lib/features/users/draft-admin-card/index.svelte
+++ b/src/lib/features/users/draft-admin-card/index.svelte
@@ -36,10 +36,10 @@
   });
 </script>
 
-<Card.Root {id}>
+<Card.Root {id} class="@container">
   <Card.Header class="gap-3 pb-2">
     <div
-      class="flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4"
+      class="flex flex-col items-start gap-2 @lg:flex-row @lg:items-center @lg:justify-between @lg:gap-4"
     >
       <Card.Title class="text-2xl">Draft Administrators</Card.Title>
       {@render children?.()}
@@ -53,7 +53,7 @@
     {#if registeredAdmins.length === 0}
       <p class="text-sm text-muted-foreground">No registered users.</p>
     {:else}
-      <ul class="space-y-2">
+      <ul class="@container space-y-2">
         {#each registeredAdmins as user (user.id)}
           <li>
             <AdminRow

--- a/src/lib/features/users/draft-admin-card/volunteer-button.svelte
+++ b/src/lib/features/users/draft-admin-card/volunteer-button.svelte
@@ -17,7 +17,7 @@
     {size}
     class="h-auto max-w-full gap-2 py-2 text-left leading-tight whitespace-normal"
   >
-    <ShieldAlertIcon class="size-6 md:size-4" />
+    <ShieldAlertIcon class="size-6 @lg:size-4" />
     <span>Volunteer as Candidate Sender</span>
   </Button>
 </form>

--- a/src/routes/(landing)/+page.svelte
+++ b/src/routes/(landing)/+page.svelte
@@ -11,8 +11,10 @@
   import { ContributorTabs } from '$lib/features/contributors';
 </script>
 
-<Hero />
-<div class="mb-8 px-10 lg:px-56">
+<div class="m-6">
+  <Hero />
+</div>
+<div class="space-y-8 px-10 pb-8 lg:px-56">
   <section class="prose max-w-none dark:prose-invert">
     <p>
       Welcome to <strong>DRAP</strong>: the <strong>Draft Ranking Automated Processor</strong> for
@@ -25,7 +27,7 @@
     </p>
   </section>
 
-  <section class="my-8 prose max-w-none dark:prose-invert prose-h3:mt-0 prose-h3:mb-2 prose-li:m-0">
+  <section class="prose max-w-none dark:prose-invert prose-h3:mt-0 prose-h3:mb-2 prose-li:m-0">
     <h2 class="border-b border-border pb-2">How It Works</h2>
     <ol class="mx-auto max-w-prose pl-0">
       <li class="grid grid-cols-[auto_1fr] gap-4">
@@ -122,8 +124,8 @@
     </ol>
   </section>
 
-  <section class="my-8">
-    <div class="my-6 prose max-w-none dark:prose-invert">
+  <section class="space-y-6">
+    <div class="prose max-w-none dark:prose-invert">
       <h2 class="border-b border-border pb-2">Getting Started</h2>
       <p>
         All interactions with the application require UP Mail authentication. The next steps depend
@@ -231,7 +233,7 @@
     </Accordion.Root>
   </section>
 
-  <section class="my-8">
+  <section>
     <div class="prose max-w-none dark:prose-invert">
       <h2 class="border-b border-border pb-2">Acknowledgements</h2>
       <p>
@@ -254,12 +256,10 @@
     </div>
   </section>
 
-  <section class="my-8">
-    <div class="prose max-w-none dark:prose-invert">
-      <h2 class="border-b border-border pb-2">Contributors</h2>
-      <div class="not-prose contents">
-        <ContributorTabs />
-      </div>
+  <section class="space-y-6 prose max-w-none dark:prose-invert">
+    <h2 class="border-b border-border pb-2">Contributors</h2>
+    <div class="not-prose">
+      <ContributorTabs />
     </div>
   </section>
 </div>

--- a/src/routes/dashboard/(draft)/labs/+page.svelte
+++ b/src/routes/dashboard/(draft)/labs/+page.svelte
@@ -9,26 +9,27 @@
   const isRegistrationActive = $derived(typeof draft !== 'undefined' && draft.currRound === 0);
 </script>
 
-{#if typeof draft !== 'undefined'}
-  {@const { id: draftId, activePeriodStart } = draft}
-  {@const startDate = format(activePeriodStart, 'PPP')}
-  {@const startTime = format(activePeriodStart, 'pp')}
-  {#if isRegistrationActive}
-    <Callout variant="destructive" class="mb-4">
-      <span
-        ><strong>Draft #{draftId}</strong> registration is ongoing. The lab catalog is locked to prevent
-        inconsistencies while students are submitting their rankings.</span
-      >
-    </Callout>
-  {:else}
-    <Callout variant="warning" class="mb-4">
-      <span
-        ><strong>Draft #{draftId}</strong> started last <strong>{startDate}</strong> at
-        <strong>{startTime}</strong>. Changes on this page only affect the lab catalog and will not
-        be reflected in the currently active draft.</span
-      >
-    </Callout>
+<div class="space-y-4">
+  {#if typeof draft !== 'undefined'}
+    {@const { id: draftId, activePeriodStart } = draft}
+    {@const startDate = format(activePeriodStart, 'PPP')}
+    {@const startTime = format(activePeriodStart, 'pp')}
+    {#if isRegistrationActive}
+      <Callout variant="destructive">
+        <span
+          ><strong>Draft #{draftId}</strong> registration is ongoing. The lab catalog is locked to prevent
+          inconsistencies while students are submitting their rankings.</span
+        >
+      </Callout>
+    {:else}
+      <Callout variant="warning">
+        <span
+          ><strong>Draft #{draftId}</strong> started last <strong>{startDate}</strong> at
+          <strong>{startTime}</strong>. Changes on this page only affect the lab catalog and will
+          not be reflected in the currently active draft.</span
+        >
+      </Callout>
+    {/if}
   {/if}
-{/if}
-
-<LabTable {labs} disabled={isRegistrationActive} draftId={draft?.id} />
+  <LabTable {labs} disabled={isRegistrationActive} draftId={draft?.id} />
+</div>

--- a/src/routes/dashboard/users/+page.svelte
+++ b/src/routes/dashboard/users/+page.svelte
@@ -15,8 +15,8 @@
   );
 </script>
 
-<h2 class="mb-6 scroll-m-20 text-3xl font-semibold tracking-tight">Users</h2>
 <div class="space-y-6">
+  <h2 class="scroll-m-20 text-3xl font-semibold tracking-tight">Users</h2>
   <Card.Root>
     <Card.Header
       class="flex flex-col items-start gap-2 pb-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4 sm:space-y-0"


### PR DESCRIPTION
This refactors feature-level responsive behavior to use component-scoped container queries where the layout depends on the rendered component width instead of the viewport. The main draft timeline cards, chart headers, contributor grids, student lab preference form, and draft administrator rows now adapt to their local containers.

The change also consolidates timeline stat-card layout rules behind a shared `StatCardGroup` component so summary, registration, intervention, and lottery phases use one consistent responsive container. Related spacing cleanup moves inter-component spacing to parents through `gap-*` or `space-y-*`, while preserving component-specific visual styling such as the landing hero banner background and blend filter.

Closes #210.

## Implementation Notes

### Container-Scoped Responsive Layouts

- Converted responsive variants on feature components from viewport breakpoints to Tailwind container variants where the component already has a meaningful wrapper.
- Added `@container` to card/form/tab wrappers that own the relevant local width.
- Kept broad chart header splits at larger container thresholds, while compact controls switch earlier at `@lg`.

### Shared Timeline Stat Cards

- Added `StatCardGroup` with explicit `columns` variants for the existing one-card, two-card, and five-card stat groups.
- The group keeps cards full-width in narrow containers, then restores the compact `w-fit` layout for one-card and two-card groups once the container has enough room.
- Five-card groups share one layout scale instead of repeating per-phase grid classes.

### Layout Spacing Ownership

- Removed leaf-level margin and padding where a parent wrapper can own the section rhythm.
- Replaced isolated `mb-*`, `mt-*`, and page-level margin patterns with parent `space-y-*` or `gap-*` wrappers in the landing page, labs page, users page, assignment display, contributor tabs, and empty media.
- Kept the landing hero's visual treatment internal, while moving its outer page margin to the landing page wrapper.

## Test Cases

Focus on the default container query sizes in TailwindCSS. The new container breakpoints should roughly approximate (if not exactly match) the prior viewport breakpoints. No new styles should be introduced; expect mostly mechanical code changes to the existing layout.

- [ ] Verify draft summary stat cards are full-width in narrow containers and compact into a two-column group once their container has enough room.
- [ ] Verify lottery and intervention stat cards expand to full-width stacked cards on mobile and progressively add columns at wider container sizes.
- [ ] Verify timeline chart card headers keep controls stacked in narrow cards and move controls inline only when the card container is wide enough.
- [ ] Verify the student lab preference form switches from one to two columns based on form container width.
- [ ] Verify draft administrator rows and volunteer actions respond to the card/list container width instead of the viewport.
- [ ] Verify the landing hero still preserves its banner background, blend treatment, and outer page spacing.
