### PR TITLE
chore(ui): update personal contributor links for Ehren

### DIFF
--- a/src/lib/features/contributors/index.svelte
+++ b/src/lib/features/contributors/index.svelte
@@ -62,7 +62,8 @@
       avatar: 'https://avatars.githubusercontent.com/u/59799738',
       roles: { '2025': 'Engineer', '2026': 'App Team: Engineer' },
       github: 'ehrelevant',
-      website: 'https://www.ehrencastillo.tech/',
+      website: 'https://www.ehrelevant.dev/',
+      linkedin: 'ehren-castillo',
     },
     {
       name: 'Marcus Pascual',


### PR DESCRIPTION
Update personal contributor links for Ehren — fixes the website URL to the current domain `ehrelevant.dev` and adds a LinkedIn profile link.

## Test Cases

- [ ] Contributors section renders with updated website link
- [ ] LinkedIn icon/link appears for Ehren's entry
