### PR TITLE
feat(app): add lab head demotion and re-invitation support

### DIFF
--- a/src/lib/components/ui/chart/chart-style.svelte
+++ b/src/lib/components/ui/chart/chart-style.svelte
@@ -27,11 +27,13 @@
     }
     return themeContents.join('\n');
   });
+
+  const STYLE_TAG = 'style';
 </script>
 
 {#if themeContents}
   {#key id}
-    <svelte:element this={"style"}>
+    <svelte:element this={STYLE_TAG}>
       {themeContents}
     </svelte:element>
   {/key}

--- a/src/lib/components/ui/chart/chart-style.svelte
+++ b/src/lib/components/ui/chart/chart-style.svelte
@@ -31,7 +31,7 @@
 
 {#if themeContents}
   {#key id}
-    <svelte:element this={'style'}>
+    <svelte:element this={"style"}>
       {themeContents}
     </svelte:element>
   {/key}

--- a/src/lib/users/faculty.svelte
+++ b/src/lib/users/faculty.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
+  import ArrowDownIcon from '@lucide/svelte/icons/arrow-down';
   import UserCircleIcon from '@lucide/svelte/icons/circle-user';
+  import { toast } from 'svelte-sonner';
 
   import * as Avatar from '$lib/components/ui/avatar';
   import * as Card from '$lib/components/ui/card';
+  import { assert } from '$lib/assert';
+  import { Button } from '$lib/components/ui/button';
+  import { enhance } from '$app/forms';
   import type { schema } from '$lib/server/database/drizzle';
 
-  interface User extends Pick<schema.User, 'email' | 'givenName' | 'familyName' | 'avatarUrl'> {
+  interface User extends Pick<
+    schema.User,
+    'id' | 'email' | 'givenName' | 'familyName' | 'avatarUrl'
+  > {
     labName: string | null;
   }
 
@@ -14,11 +22,11 @@
   }
 
   const { user }: Props = $props();
-  const { email, givenName, familyName, avatarUrl, labName } = $derived(user);
+  const { id, email, givenName, familyName, avatarUrl, labName } = $derived(user);
 </script>
 
-<a href="mailto:{email}" class="block h-full transition-transform duration-150 hover:scale-[1.02]">
-  <Card.Root class="flex h-full flex-col items-center gap-4 p-4 text-center">
+<div class="block h-full">
+  <Card.Root class="flex h-full flex-col justify-center items-center gap-4 p-4 text-center">
     <Avatar.Root class="size-16">
       <Avatar.Image src={avatarUrl} alt="{givenName} {familyName}" />
       <Avatar.Fallback>
@@ -35,8 +43,50 @@
         {#if labName !== null}
           <span class="text-sm font-medium text-foreground">{labName}</span>
         {/if}
-        <span class="text-xs text-muted-foreground">{email}</span>
+        <a href="mailto:{email}" class="text-xs text-muted-foreground hover:underline">
+          {email}
+        </a>
       </div>
     </div>
+    <Card.Footer class="w-full flex justify-center p-0">
+      <form
+        method="post"
+        action="/dashboard/users/?/demote-head"
+        use:enhance={({ submitter, cancel }) => {
+          // eslint-disable-next-line no-alert
+          if (!confirm(`Are you sure you want to demote ${familyName}, ${givenName} to Lab Faculty?`)) {
+            cancel();
+            return;
+          }
+          assert(submitter !== null);
+          assert(submitter instanceof HTMLButtonElement);
+          submitter.disabled = true;
+          return async ({ update, result }) => {
+            submitter.disabled = false;
+            await update();
+            switch (result.type) {
+              case 'success':
+                toast.success(`${familyName}, ${givenName} demoted to Lab Faculty.`);
+                break;
+              case 'failure':
+                toast.error('Failed to demote lab head.');
+                break;
+              default:
+                break;
+            }
+          };
+        }}
+      >
+        <input type="hidden" name="userId" value={id} />
+        <Button
+          type="submit"
+          variant="destructive"
+          class="h-auto max-w-full gap-2 py-2 text-left leading-tight whitespace-normal"
+        >
+          <ArrowDownIcon class="size-6 @lg:size-4" />
+          <span>Demote</span>
+        </Button>
+      </form>
+    </Card.Footer>
   </Card.Root>
-</a>
+</div>

--- a/src/lib/users/faculty.svelte
+++ b/src/lib/users/faculty.svelte
@@ -54,7 +54,9 @@
         action="/dashboard/users/?/demote-head"
         use:enhance={({ submitter, cancel }) => {
           // eslint-disable-next-line no-alert
-          if (!confirm(`Are you sure you want to demote ${familyName}, ${givenName} to Lab Faculty?`)) {
+          if (
+            !confirm(`Are you sure you want to demote ${familyName}, ${givenName} to Lab Faculty?`)
+          ) {
             cancel();
             return;
           }

--- a/src/lib/users/faculty.svelte
+++ b/src/lib/users/faculty.svelte
@@ -82,12 +82,8 @@
         }}
       >
         <input type="hidden" name="userId" value={id} />
-        <Button
-          type="submit"
-          variant="destructive"
-          class="h-auto max-w-full gap-2 py-2 text-left leading-tight whitespace-normal"
-        >
-          <ArrowDownIcon class="size-6 @lg:size-4" />
+        <Button type="submit" variant="destructive" size="sm">
+          <ArrowDownIcon class="size-4" />
           <span>Demote</span>
         </Button>
       </form>

--- a/src/lib/users/faculty.svelte
+++ b/src/lib/users/faculty.svelte
@@ -55,7 +55,9 @@
         use:enhance={({ submitter, cancel }) => {
           // eslint-disable-next-line no-alert
           if (
-            !confirm(`Are you sure you want to demote ${familyName}, ${givenName} to Lab Faculty?`)
+            !confirm(
+              `Are you sure you want to demote ${givenName} ${familyName} as a lab faculty member?`,
+            )
           ) {
             cancel();
             return;
@@ -68,7 +70,7 @@
             await update();
             switch (result.type) {
               case 'success':
-                toast.success(`${familyName}, ${givenName} demoted to Lab Faculty.`);
+                toast.success(`${givenName} ${familyName} demoted as a lab faculty member.`);
                 break;
               case 'failure':
                 toast.error('Failed to demote lab head.');

--- a/src/routes/dashboard/users/+page.server.ts
+++ b/src/routes/dashboard/users/+page.server.ts
@@ -28,6 +28,10 @@ const DeleteInviteFormData = v.object({
   id: v.pipe(v.string(), v.minLength(1)),
 });
 
+const DemoteHeadFormData = v.object({
+  userId: v.pipe(v.string(), v.minLength(1)),
+});
+
 const SenderFormData = v.object({
   userId: v.pipe(v.string(), v.minLength(1)),
 });
@@ -242,6 +246,39 @@ export const actions = {
       error(404, 'Designated sender does not exist.');
     });
   },
+  async 'demote-head'({ locals: { session }, request }) {
+    if (typeof session?.user === 'undefined') {
+      logger.fatal('attempt to demote lab head without session');
+      error(401);
+    }
+
+    if (
+      !session.user.isAdmin ||
+      session.user.googleUserId === null ||
+      session.user.labId !== null
+    ) {
+      logger.fatal('insufficient permissions to demote lab head', void 0, {
+        'user.is_admin': session.user.isAdmin,
+        'user.google_id': session.user.googleUserId,
+        'user.lab_id': session.user.labId,
+      });
+      error(403);
+    }
+
+    return await tracer.asyncSpan('action.demote-head', async () => {
+      const data = await request.formData();
+      const { userId } = v.parse(DemoteHeadFormData, decode(data));
+      logger.debug('demoting lab head', { 'user.id': userId });
+
+      if (await demoteLabHead(db, userId)) {
+        logger.info('lab head demoted to member', { 'user.id': userId });
+        return;
+      }
+
+      logger.fatal('user is not a lab head', void 0, { 'user.id': userId });
+      error(404, 'User is not a lab head.');
+    });
+  },
   async remove({ locals: { session }, request }) {
     if (typeof session?.user === 'undefined') {
       logger.fatal('attempt to remove sender without session');
@@ -381,6 +418,30 @@ async function deleteDesignatedSender(db: DbConnection, userId: string) {
         return true;
       default:
         assertFail(`deleteDesignatedSender => unexpected delete count ${rowCount}`);
+    }
+  });
+}
+
+async function demoteLabHead(db: DbConnection, userId: string) {
+  return await tracer.asyncSpan('demote-lab-head', async span => {
+    span.setAttribute('database.user.id', userId);
+    const { rowCount } = await db
+      .update(schema.user)
+      .set({ isAdmin: false })
+      .where(
+        and(
+          eq(schema.user.id, userId),
+          eq(schema.user.isAdmin, true),
+          isNotNull(schema.user.labId),
+        ),
+      );
+    switch (rowCount) {
+      case 0:
+        return false;
+      case 1:
+        return true;
+      default:
+        assertFail(`demoteLabHead => unexpected update count ${rowCount}`);
     }
   });
 }

--- a/src/routes/dashboard/users/+page.server.ts
+++ b/src/routes/dashboard/users/+page.server.ts
@@ -324,9 +324,8 @@ async function inviteNewFacultyOrStaff(db: DbConnection, email: string, labId: s
       .onConflictDoUpdate({
         target: schema.user.email,
         set: { isAdmin: true, labId },
-        setWhere: labId === null
-          ? isNull(schema.user.googleUserId)
-          : eq(schema.user.isAdmin, false),
+        setWhere:
+          labId === null ? isNull(schema.user.googleUserId) : eq(schema.user.isAdmin, false),
       });
     switch (rowCount) {
       case 0:

--- a/src/routes/dashboard/users/+page.server.ts
+++ b/src/routes/dashboard/users/+page.server.ts
@@ -321,7 +321,13 @@ async function inviteNewFacultyOrStaff(db: DbConnection, email: string, labId: s
     const { rowCount } = await db
       .insert(schema.user)
       .values({ email, labId, isAdmin: true })
-      .onConflictDoNothing({ target: schema.user.email });
+      .onConflictDoUpdate({
+        target: schema.user.email,
+        set: { isAdmin: true, labId },
+        setWhere: labId === null
+          ? isNull(schema.user.googleUserId)
+          : eq(schema.user.isAdmin, false),
+      });
     switch (rowCount) {
       case 0:
         return false;

--- a/src/routes/dashboard/users/+page.svelte
+++ b/src/routes/dashboard/users/+page.svelte
@@ -29,7 +29,7 @@
         <p class="text-sm text-muted-foreground">No registered users.</p>
       {:else}
         <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-          {#each registeredHeads as { id, ...user } (id)}
+          {#each registeredHeads as user (user.id)}
             <Faculty {user} />
           {/each}
         </div>

--- a/tests/draft.test.ts
+++ b/tests/draft.test.ts
@@ -394,6 +394,70 @@ test.describe('Draft Lifecycle', () => {
     });
   });
 
+  test.describe('Lab Head Demotion', () => {
+    test('lab head card shows demote button for each lab head', async ({ adminPage }) => {
+      await adminPage.goto('/dashboard/users/');
+      await expect(adminPage.getByRole('button', { name: 'Demote', exact: true })).toHaveCount(5);
+    });
+
+    test('demote removes a lab head from the section', async ({ adminPage, ndslHeadUserId }) => {
+      await adminPage.goto('/dashboard/users/');
+      await expect(adminPage.getByText('ndsl@up.edu.ph')).toBeVisible();
+      await expect(adminPage.getByRole('button', { name: 'Demote', exact: true })).toHaveCount(5);
+
+      const status = await adminPage.evaluate(async userId => {
+        const data = new FormData();
+        data.set('userId', userId);
+        const response = await fetch('/dashboard/users/?/demote-head', {
+          method: 'POST',
+          body: data,
+        });
+        return response.status;
+      }, ndslHeadUserId);
+      expect(status).toBe(200);
+
+      await adminPage.reload();
+      await expect(adminPage.getByText('ndsl@up.edu.ph')).not.toBeVisible();
+      await expect(adminPage.getByRole('button', { name: 'Demote', exact: true })).toHaveCount(4);
+    });
+
+    test('demoting a non-lab-head returns 404', async ({ adminPage, adminUserId }) => {
+      const status = await adminPage.evaluate(async userId => {
+        const data = new FormData();
+        data.set('userId', userId);
+        const response = await fetch('/dashboard/users/?/demote-head', {
+          method: 'POST',
+          body: data,
+        });
+        return response.status;
+      }, adminUserId);
+      expect(status).toBe(404);
+    });
+
+    test('re-inviting a demoted lab head restores them', async ({ adminPage }) => {
+      await adminPage.goto('/dashboard/users/');
+      await expect(adminPage.getByText('ndsl@up.edu.ph')).not.toBeVisible();
+      await expect(adminPage.getByRole('button', { name: 'Demote', exact: true })).toHaveCount(4);
+
+      await adminPage.getByRole('button', { name: 'Manage Invitations' }).first().click();
+      const sheet = adminPage.getByRole('dialog');
+      await expect(sheet).toBeVisible();
+      await sheet.locator('select#lab-select').selectOption('ndsl');
+      await sheet.locator('input#faculty-email').fill('ndsl@up.edu.ph');
+
+      const responsePromise = adminPage.waitForResponse('/dashboard/users/?/faculty');
+      await sheet.getByRole('button', { name: 'Invite' }).click();
+      const response = await responsePromise;
+      const responseData = await response.json();
+      expect(responseData.type).toBe('success');
+
+      await adminPage.keyboard.press('Escape');
+      await adminPage.reload();
+      await expect(adminPage.getByText('ndsl@up.edu.ph')).toBeVisible();
+      await expect(adminPage.getByRole('button', { name: 'Demote', exact: true })).toHaveCount(5);
+    });
+  });
+
   test.describe('Student Profile Registration', () => {
     test('Eager lands on /dashboard/student/', async ({ eagerDrafteePage }) => {
       await expect(eagerDrafteePage).toHaveURL('/dashboard/student/');


### PR DESCRIPTION
Closes #276.

Add the ability for draft administrators to demote lab heads to lab faculty on the admin users page, and allow demoted lab heads to be re-invited back to lab head status.

A "Demote" button now appears on each lab head card in the Lab Heads section of `/dashboard/users/`. Clicking triggers a confirmation dialog, then sets the user's `isAdmin` flag to `false` while preserving their lab affiliation. A toast confirms the result.

The `inviteNewFacultyOrStaff` upsert was updated from `onConflictDoNothing` to `onConflictDoUpdate` so that demoted lab heads (or other non-admin users with the same email) can be re-invited instead of rejected with a 409 conflict:

- **Lab head invites** (`labId` set): updates `isAdmin = true` only if existing user is not already an admin (`setWhere: isAdmin = false`).
- **Draft admin invites** (`labId` null): updates `isAdmin = true` only the user has never signed in via Google (`setWhere: googleUserId IS NULL`), preventing a scenario where promoting a user to draft admin silently makes them a lab head instead (because they already have a `labId`). 

## Test Cases

- [ ] Lab head card shows a "Demote" button for each registered lab head
- [ ] Demoting a lab head removes them from the Lab Heads section
- [ ] Demoting a non-lab-head user returns a 404
- [ ] Re-inviting a demoted lab head restores them to the Lab Heads section
