### PR TITLE
refactor(ui): polish the lab head dashboard

### DIFF
--- a/src/lib/features/drafts/init/form.svelte
+++ b/src/lib/features/drafts/init/form.svelte
@@ -30,17 +30,26 @@
     const closesAt = new Date(closesAtRaw);
     formData.set('closesAt', closesAt.toISOString());
 
-    const rounds = formData.get('rounds');
-    assert(typeof rounds === 'string');
-    if (
-      // eslint-disable-next-line no-alert
-      !confirm(
-        `Are you sure you want to start a new draft with ${rounds} rounds and with registration that closes at ${format(closesAt, 'PPPpp')}?`,
-      )
-    ) {
+    const rawRounds = formData.get('rounds');
+    assert(typeof rawRounds === 'string');
+    const rounds = Number.parseInt(rawRounds, 10);
+
+    let message: string;
+    switch (rounds) {
+      case 1:
+        message = 'Are you sure you want to start a new draft with only a single round?';
+        break;
+      default:
+        message = `Are you sure you want to start a new draft with ${rounds} rounds?`;
+        break;
+    }
+
+    // eslint-disable-next-line no-alert
+    if (!confirm(message)) {
       cancel();
       return;
     }
+
     assert(submitter !== null);
     assert(submitter instanceof HTMLButtonElement);
     submitter.disabled = true;

--- a/src/lib/features/drafts/init/form.svelte
+++ b/src/lib/features/drafts/init/form.svelte
@@ -6,7 +6,6 @@
 
 <script lang="ts">
   import CalendarDaysIcon from '@lucide/svelte/icons/calendar-days';
-  import { format } from 'date-fns';
   import { toast } from 'svelte-sonner';
 
   import { assert } from '$lib/assert';

--- a/src/lib/features/faculty/previous-picks/index.svelte
+++ b/src/lib/features/faculty/previous-picks/index.svelte
@@ -25,7 +25,7 @@
   const latestRound = $derived(Math.max(...Object.keys(researchersByRound).map(Number)).toString());
 </script>
 
-<Card.Root id="previous-picks" variant="soft" class="min-h-0">
+<Card.Root id="previous-picks" variant="soft">
   <Card.Header>
     <Card.Title>Previous Picks</Card.Title>
   </Card.Header>

--- a/src/lib/features/faculty/previous-picks/index.svelte
+++ b/src/lib/features/faculty/previous-picks/index.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
+  import ClipboardListIcon from '@lucide/svelte/icons/clipboard-list';
+
   import * as Card from '$lib/components/ui/card';
   import * as Tabs from '$lib/components/ui/tabs';
   import DraftAvatar from '$lib/components/draft-avatar.svelte';
+  import Empty from '$lib/components/empty.svelte';
   import type { schema } from '$lib/server/database/drizzle';
 
   interface Researcher extends Pick<
@@ -22,52 +25,60 @@
   const latestRound = $derived(Math.max(...Object.keys(researchersByRound).map(Number)).toString());
 </script>
 
-<Card.Root id="previous-picks" variant="soft">
+<Card.Root id="previous-picks" variant="soft" class="min-h-0">
   <Card.Header>
     <Card.Title>Previous Picks</Card.Title>
   </Card.Header>
-  <Card.Content>
-    <Tabs.Root value={latestRound}>
-      <Tabs.List>
-        {#each Object.keys(researchersByRound)
-          .map(Number)
-          .toSorted((a, b) => a - b) as round (round)}
-          <Tabs.Trigger value={round.toString()}>Round {round}</Tabs.Trigger>
-        {/each}
-      </Tabs.List>
-      {#each Object.entries(researchersByRound) as [round, students = []] (round)}
-        <Tabs.Content value={round}>
-          <ul class="space-y-1">
-            {#each students as { email, givenName, familyName, avatarObjectKey, studentNumber } (email)}
-              <li>
-                <a
-                  href="mailto:{email}"
-                  class="flex items-center gap-3 rounded-md bg-muted p-2 transition-colors duration-150 hover:bg-muted/80"
-                >
-                  {#if avatarObjectKey === null}
-                    <DraftAvatar class="size-10" />
-                  {:else}
-                    <DraftAvatar
-                      avatar={{
-                        objectKey: avatarObjectKey,
-                        alt: `${givenName} ${familyName}`,
-                      }}
-                      class="size-10"
-                    />
-                  {/if}
-                  <div class="flex grow flex-col">
-                    <strong><span class="uppercase">{familyName}</span>, {givenName}</strong>
-                    {#if studentNumber !== null}
-                      <span class="text-sm opacity-50">{studentNumber}</span>
+  <Card.Content class="min-h-0 flex grow flex-col">
+    {#if researchers.length === 0}
+      <Empty media={{ icon: ClipboardListIcon, size: 'sm' }}>
+        {#snippet title()}No Picks Yet{/snippet}
+        {#snippet description()}Students you select will appear here after each round.{/snippet}
+      </Empty>
+    {:else}
+      {@const sortedRounds = Object.keys(researchersByRound)
+        .map(Number)
+        .sort((a, b) => a - b)}
+      <Tabs.Root value={latestRound}>
+        <Tabs.List>
+          {#each sortedRounds as round (round)}
+            <Tabs.Trigger value={round.toString()}>Round {round}</Tabs.Trigger>
+          {/each}
+        </Tabs.List>
+        {#each Object.entries(researchersByRound) as [round, students = []] (round)}
+          <Tabs.Content value={round}>
+            <ul class="space-y-1">
+              {#each students as { email, givenName, familyName, avatarObjectKey, studentNumber } (email)}
+                <li>
+                  <a
+                    href="mailto:{email}"
+                    class="flex items-center gap-3 rounded-md bg-muted p-2 transition-colors duration-150 hover:bg-muted/80"
+                  >
+                    {#if avatarObjectKey === null}
+                      <DraftAvatar class="size-10" />
+                    {:else}
+                      <DraftAvatar
+                        avatar={{
+                          objectKey: avatarObjectKey,
+                          alt: `${givenName} ${familyName}`,
+                        }}
+                        class="size-10"
+                      />
                     {/if}
-                    <span class="text-xs opacity-50">{email}</span>
-                  </div>
-                </a>
-              </li>
-            {/each}
-          </ul>
-        </Tabs.Content>
-      {/each}
-    </Tabs.Root>
+                    <div class="flex grow flex-col">
+                      <strong><span class="uppercase">{familyName}</span>, {givenName}</strong>
+                      {#if studentNumber !== null}
+                        <span class="text-sm opacity-50">{studentNumber}</span>
+                      {/if}
+                      <span class="text-xs opacity-50">{email}</span>
+                    </div>
+                  </a>
+                </li>
+              {/each}
+            </ul>
+          </Tabs.Content>
+        {/each}
+      </Tabs.Root>
+    {/if}
   </Card.Content>
 </Card.Root>

--- a/src/lib/features/faculty/stat-cards/index.svelte
+++ b/src/lib/features/faculty/stat-cards/index.svelte
@@ -3,6 +3,7 @@
 
   import * as Card from '$lib/components/ui/card';
   import * as Popover from '$lib/components/ui/popover';
+  import { cn } from '$lib/components/ui/utils';
 
   interface Props {
     quota: number;
@@ -28,59 +29,61 @@
   });
 </script>
 
-<div class="grid grid-cols-2 gap-2 sm:grid-cols-3">
-  <Card.Root variant="soft" class="preset-tonal-muted">
-    <Card.Header>
-      <Card.Title class="flex items-center gap-1.5">
-        Total Quota
-        <Popover.Root>
-          <Popover.Trigger>
-            <CircleHelpIcon class="size-3.5 text-muted-foreground" />
-          </Popover.Trigger>
-          <Popover.Content class="text-sm">
-            Total slots allocated to your lab for this draft.
-          </Popover.Content>
-        </Popover.Root>
-      </Card.Title>
-    </Card.Header>
-    <Card.Content>
-      <p id="stat-total-quota" class="text-2xl font-semibold tabular-nums">{quota}</p>
-    </Card.Content>
-  </Card.Root>
-  <Card.Root variant="soft" class={remainingTonal}>
-    <Card.Header>
-      <Card.Title class="flex items-center gap-1.5">
-        Remaining This Round
-        <Popover.Root>
-          <Popover.Trigger>
-            <CircleHelpIcon class="size-3.5 text-muted-foreground" />
-          </Popover.Trigger>
-          <Popover.Content class="text-sm">
-            Slots you can still fill. You're not required to exhaust your allocation this round.
-          </Popover.Content>
-        </Popover.Root>
-      </Card.Title>
-    </Card.Header>
-    <Card.Content>
-      <p id="stat-remaining" class="text-2xl font-semibold tabular-nums">{remainingQuota}</p>
-    </Card.Content>
-  </Card.Root>
-  <Card.Root variant="soft" class="preset-tonal-accent col-span-2 sm:col-span-1">
-    <Card.Header>
-      <Card.Title class="flex items-center gap-1.5">
-        Drafted So Far
-        <Popover.Root>
-          <Popover.Trigger>
-            <CircleHelpIcon class="size-3.5 text-muted-foreground" />
-          </Popover.Trigger>
-          <Popover.Content class="text-sm">
-            Students your lab selected in previous rounds.
-          </Popover.Content>
-        </Popover.Root>
-      </Card.Title>
-    </Card.Header>
-    <Card.Content>
-      <p id="stat-drafted" class="text-2xl font-semibold tabular-nums">{draftedCount}</p>
-    </Card.Content>
-  </Card.Root>
+<div class="@container">
+  <div class="grid grid-cols-1 gap-2 @xs:grid-cols-3">
+    <Card.Root variant="soft" class="preset-tonal-muted gap-1 py-3">
+      <Card.Header>
+        <Card.Title class="flex items-center gap-1.5 text-xs font-medium">
+          Total Quota
+          <Popover.Root>
+            <Popover.Trigger>
+              <CircleHelpIcon class="size-3.5 text-muted-foreground" />
+            </Popover.Trigger>
+            <Popover.Content class="text-sm">
+              Total slots allocated to your lab for this draft.
+            </Popover.Content>
+          </Popover.Root>
+        </Card.Title>
+      </Card.Header>
+      <Card.Content>
+        <p id="stat-total-quota" class="text-lg font-semibold tabular-nums">{quota}</p>
+      </Card.Content>
+    </Card.Root>
+    <Card.Root variant="soft" class={cn(remainingTonal, 'gap-1 py-3')}>
+      <Card.Header>
+        <Card.Title class="flex items-center gap-1.5 text-xs font-medium">
+          Remaining This Round
+          <Popover.Root>
+            <Popover.Trigger>
+              <CircleHelpIcon class="size-3.5 text-muted-foreground" />
+            </Popover.Trigger>
+            <Popover.Content class="text-sm">
+              Slots you can still fill. You're not required to exhaust your allocation this round.
+            </Popover.Content>
+          </Popover.Root>
+        </Card.Title>
+      </Card.Header>
+      <Card.Content>
+        <p id="stat-remaining" class="text-lg font-semibold tabular-nums">{remainingQuota}</p>
+      </Card.Content>
+    </Card.Root>
+    <Card.Root variant="soft" class="preset-tonal-accent gap-1 py-3">
+      <Card.Header>
+        <Card.Title class="flex items-center gap-1.5 text-xs font-medium">
+          Drafted So Far
+          <Popover.Root>
+            <Popover.Trigger>
+              <CircleHelpIcon class="size-3.5 text-muted-foreground" />
+            </Popover.Trigger>
+            <Popover.Content class="text-sm">
+              Students your lab selected in previous rounds.
+            </Popover.Content>
+          </Popover.Root>
+        </Card.Title>
+      </Card.Header>
+      <Card.Content>
+        <p id="stat-drafted" class="text-lg font-semibold tabular-nums">{draftedCount}</p>
+      </Card.Content>
+    </Card.Root>
+  </div>
 </div>

--- a/src/lib/features/student/registration-open/lab-preference-form.svelte
+++ b/src/lib/features/student/registration-open/lab-preference-form.svelte
@@ -114,10 +114,20 @@
   action="/dashboard/student/?/submit"
   class="@container space-y-4"
   use:enhance={({ submitter, cancel }) => {
-    const message =
-      persistedSelectedLabs.current.length === 0
-        ? 'Are you sure you want to skip lab preferences? You will go directly to the lottery.'
-        : `Are you sure you want to select ${persistedSelectedLabs.current.length} labs?`;
+    let message: string;
+    const labCount = persistedSelectedLabs.current.length;
+    switch (labCount) {
+      case 0:
+        message =
+          'Are you sure you want to skip lab preferences? You will go directly to the lottery.';
+        break;
+      case 1:
+        message = 'Are you sure you want to select only one lab?';
+        break;
+      default:
+        message = `Are you sure you want to select these ${labCount} labs?`;
+        break;
+    }
 
     // eslint-disable-next-line no-alert
     if (!confirm(message)) {

--- a/src/lib/users/faculty.svelte
+++ b/src/lib/users/faculty.svelte
@@ -53,8 +53,8 @@
         method="post"
         action="/dashboard/users/?/demote-head"
         use:enhance={({ submitter, cancel }) => {
-          // eslint-disable-next-line no-alert
           if (
+            // eslint-disable-next-line no-alert
             !confirm(
               `Are you sure you want to demote ${givenName} ${familyName} as a lab faculty member?`,
             )

--- a/src/routes/dashboard/(faculty)/+layout.svelte
+++ b/src/routes/dashboard/(faculty)/+layout.svelte
@@ -45,4 +45,6 @@
     </p>
   </Alert.Description>
 </Alert.Root>
-{@render children?.()}
+<div class="min-h-0 flex grow flex-col gap-4">
+  {@render children?.()}
+</div>

--- a/src/routes/dashboard/(faculty)/students/+page.svelte
+++ b/src/routes/dashboard/(faculty)/students/+page.svelte
@@ -75,10 +75,10 @@
     />
     <div class="@container min-h-0 grow">
       <div
-        class="grid h-full grid-cols-1 grid-rows-[auto_1fr] gap-2 @md:grid-cols-2 @md:grid-rows-[1fr]"
+        class="grid h-full grid-cols-1 grid-rows-2 gap-2 @3xl:grid-cols-2 @3xl:grid-rows-[1fr]"
       >
         <PreviousPicks {researchers} />
-        <Card.Root variant="soft" class="min-h-0">
+        <Card.Root variant="soft">
           <Card.Header>
             <Card.Title>Student Selection</Card.Title>
           </Card.Header>

--- a/src/routes/dashboard/(faculty)/students/+page.svelte
+++ b/src/routes/dashboard/(faculty)/students/+page.svelte
@@ -6,6 +6,7 @@
   import ShuffleIcon from '@lucide/svelte/icons/shuffle';
   import UserXIcon from '@lucide/svelte/icons/user-x';
 
+  import * as Card from '$lib/components/ui/card';
   import Empty from '$lib/components/empty.svelte';
   import PreviousPicks from '$lib/features/faculty/previous-picks/index.svelte';
   import StatCards from '$lib/features/faculty/stat-cards/index.svelte';
@@ -44,9 +45,7 @@
         validating results before finalization.
       {/snippet}
     </Empty>
-    {#if researchers.length > 0}
-      <PreviousPicks {researchers} />
-    {/if}
+    <PreviousPicks {researchers} />
   {:else if currRound > maxRounds}
     <Empty media={{ icon: ShuffleIcon, size: 'sm' }}>
       {#snippet title()}Lottery Stage{/snippet}
@@ -55,9 +54,7 @@
         proceed.
       {/snippet}
     </Empty>
-    {#if researchers.length > 0}
-      <PreviousPicks {researchers} />
-    {/if}
+    <PreviousPicks {researchers} />
   {:else if currRound === 0}
     <Empty media={{ icon: InfoIcon, size: 'sm' }}>
       {#snippet title()}Registration Still Open{/snippet}
@@ -67,8 +64,7 @@
       {/snippet}
     </Empty>
   {:else}
-    {@const currentRoundSelections =
-      currRound === null ? [] : researchers.filter(({ round }) => round === currRound)}
+    {@const currentRoundSelections = researchers.filter(({ round }) => round === currRound)}
     {@const currentRoundSelectionIds = currentRoundSelections.map(({ id }) => id)}
     <StatCards
       {quota}
@@ -77,46 +73,57 @@
       {submissionSource}
       {autoAcknowledgeReason}
     />
-    {#if autoAcknowledgeReason === 'quota-exhausted'}
-      <Empty media={{ icon: CircleSlashIcon, size: 'sm' }}>
-        {#snippet title()}No Slots Remaining{/snippet}
-        {#snippet description()}
-          This lab has no more draft slots remaining for the rest of this draft. No action is
-          required for the rest of this draft.
-        {/snippet}
-      </Empty>
-      {#if researchers.length > 0}
+    <div class="@container min-h-0 grow">
+      <div
+        class="grid h-full grid-cols-1 grid-rows-[auto_1fr] gap-2 @md:grid-cols-2 @md:grid-rows-[1fr]"
+      >
         <PreviousPicks {researchers} />
-      {/if}
-    {:else if autoAcknowledgeReason === 'no-preferences'}
-      <Empty media={{ icon: UserXIcon, size: 'sm' }}>
-        {#snippet title()}No Student Preferences This Round{/snippet}
-        {#snippet description()}
-          No undrafted students have selected this lab in this round. No action is required until
-          the next one.
-        {/snippet}
-      </Empty>
-      {#if researchers.length > 0}
-        <PreviousPicks {researchers} />
-      {/if}
-    {:else if students.length > 0}
-      <div class="grid grid-cols-1 gap-4 sm:grid-cols-[auto_1fr]">
-        {#if researchers.length > 0}
-          <PreviousPicks {researchers} />
-        {/if}
-        {#if submissionSource === 'faculty'}
-          <RankingsForm
-            draft={id}
-            round={currRound}
-            {students}
-            remainingQuota={remainingQuota + currentRoundSelections.length}
-            initialSelectedIds={currentRoundSelectionIds}
-            hasExistingSubmission
-          />
-        {:else}
-          <RankingsForm draft={id} round={currRound} {students} {remainingQuota} />
-        {/if}
+        <Card.Root variant="soft" class="min-h-0">
+          <Card.Header>
+            <Card.Title>Student Selection</Card.Title>
+          </Card.Header>
+          <Card.Content class="min-h-0 flex grow flex-col">
+            {#if autoAcknowledgeReason === 'quota-exhausted'}
+              <Empty media={{ icon: CircleSlashIcon, size: 'sm' }}>
+                {#snippet title()}No Slots Remaining{/snippet}
+                {#snippet description()}
+                  This lab has no more draft slots remaining for the rest of this draft. No action
+                  is required for the rest of this draft.
+                {/snippet}
+              </Empty>
+            {:else if autoAcknowledgeReason === 'no-preferences'}
+              <Empty media={{ icon: UserXIcon, size: 'sm' }}>
+                {#snippet title()}No Student Preferences This Round{/snippet}
+                {#snippet description()}
+                  No undrafted students have selected this lab in this round. No action is required
+                  until the next one.
+                {/snippet}
+              </Empty>
+            {:else if students.length > 0}
+              {#if submissionSource === 'faculty'}
+                <RankingsForm
+                  draft={id}
+                  round={currRound}
+                  {students}
+                  remainingQuota={remainingQuota + currentRoundSelections.length}
+                  initialSelectedIds={currentRoundSelectionIds}
+                  hasExistingSubmission
+                />
+              {:else}
+                <RankingsForm draft={id} round={currRound} {students} {remainingQuota} />
+              {/if}
+            {:else}
+              <Empty media={{ icon: UserXIcon, size: 'sm' }}>
+                {#snippet title()}No Students Available{/snippet}
+                {#snippet description()}
+                  There are no students to select from this round. This may resolve in the next
+                  round.
+                {/snippet}
+              </Empty>
+            {/if}
+          </Card.Content>
+        </Card.Root>
       </div>
-    {/if}
+    </div>
   {/if}
 {/if}

--- a/src/routes/dashboard/(faculty)/students/+page.svelte
+++ b/src/routes/dashboard/(faculty)/students/+page.svelte
@@ -74,9 +74,7 @@
       {autoAcknowledgeReason}
     />
     <div class="@container min-h-0 grow">
-      <div
-        class="grid h-full grid-cols-1 grid-rows-2 gap-2 @3xl:grid-cols-2 @3xl:grid-rows-[1fr]"
-      >
+      <div class="grid h-full grid-cols-1 grid-rows-2 gap-2 @3xl:grid-cols-2 @3xl:grid-rows-[1fr]">
         <PreviousPicks {researchers} />
         <Card.Root variant="soft">
           <Card.Header>

--- a/src/routes/dashboard/(faculty)/students/rankings-form.svelte
+++ b/src/routes/dashboard/(faculty)/students/rankings-form.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import CircleHelpIcon from '@lucide/svelte/icons/circle-help';
+  import MessageSquareTextIcon from '@lucide/svelte/icons/message-square-text';
   import { SvelteSet } from 'svelte/reactivity';
   import { toast } from 'svelte-sonner';
 
@@ -139,7 +140,7 @@
       >
         <button
           type="button"
-          class="flex w-full flex-col gap-3 p-3"
+          class="flex w-full flex-col gap-2 p-3"
           onclick={toggleSelection.bind(null, id)}
         >
           <div class="flex items-center gap-3">
@@ -155,20 +156,22 @@
               />
             {/if}
             <div class="flex flex-col">
-              <strong class="text-start"
-                ><span class="uppercase">{familyName}</span>, {givenName}</strong
-              >
-              {#if studentNumber !== null}
-                <span class="text-start text-sm opacity-50">{studentNumber}</span>
-              {/if}
-              <span class="text-start text-xs opacity-50">{email}</span>
+              <div class="flex items-center gap-1.5">
+                <strong class="text-start"
+                  ><span class="uppercase">{familyName}</span>, {givenName}</strong
+                >
+                {#if studentNumber !== null}
+                  <Badge variant="outline">{studentNumber}</Badge>
+                {/if}
+              </div>
+              <div class="text-start text-xs opacity-50">{email}</div>
             </div>
           </div>
           {#if remark.length > 0}
-            <div class="flex flex-col gap-2">
-              <span class="text-start"><strong>Remarks</strong></span>
+            <div class="flex items-start gap-1.5">
+              <MessageSquareTextIcon class="size-3.5 shrink-0" />
               <pre
-                class="text-start font-sans text-sm whitespace-pre-wrap opacity-90">{remark}</pre>
+                class="text-start font-sans text-xs whitespace-pre-wrap text-muted-foreground">{remark}</pre>
             </div>
           {/if}
         </button>

--- a/src/routes/dashboard/(faculty)/students/rankings-form.svelte
+++ b/src/routes/dashboard/(faculty)/students/rankings-form.svelte
@@ -76,8 +76,22 @@
   action="/dashboard/students/?/rankings"
   use:enhance={({ formData, submitter, cancel }) => {
     const count = formData.getAll('students').length;
+
+    let message: string;
+    switch (count) {
+      case 0:
+        message = 'Are you sure you want to waive this round?';
+        break;
+      case 1:
+        message = 'Are you sure you want to select only one student?';
+        break;
+      default:
+        message = `Are you sure you want to select these ${count} students?`;
+        break;
+    }
+
     // eslint-disable-next-line no-alert
-    if (!confirm(`Are you sure you want to select these ${count} students?`)) {
+    if (!confirm(message)) {
       cancel();
       return;
     }

--- a/src/routes/dashboard/(faculty)/students/rankings-form.svelte
+++ b/src/routes/dashboard/(faculty)/students/rankings-form.svelte
@@ -6,6 +6,7 @@
   import * as Popover from '$lib/components/ui/popover';
   import DraftAvatar from '$lib/components/draft-avatar.svelte';
   import { assert } from '$lib/assert';
+  import { Badge } from '$lib/components/ui/badge';
   import { Button } from '$lib/components/ui/button';
   import { enhance } from '$app/forms';
   import { Progress } from '$lib/components/ui/progress';
@@ -116,14 +117,20 @@
       resetSelectionState();
     };
   }}
-  class="flex flex-col gap-4 inert:opacity-20"
+  class="flex min-h-0 grow flex-col inert:opacity-20"
 >
   <input type="hidden" name="draft" value={draft} />
   <input type="hidden" name="round" value={round} />
   {#each selectedIds as id (id)}
     <input type="hidden" name="students" value={id} />
   {/each}
-  <ul class="space-y-1">
+  <div id="selection-progress" class="flex items-center gap-3 pb-3">
+    <Progress value={selectedIds.length} max={remainingQuota} />
+    <Badge variant="secondary" class="tabular-nums"
+      >{selectedIds.length}/{remainingQuota} Slots</Badge
+    >
+  </div>
+  <ul class="min-h-0 grow space-y-2 overflow-y-auto">
     {#each students as { id, email, givenName, familyName, avatarObjectKey, studentNumber, remark } (id)}
       {@const selected = hasSelection(id)}
       <li
@@ -132,10 +139,10 @@
       >
         <button
           type="button"
-          class="flex w-full flex-col gap-3 p-2"
+          class="flex w-full flex-col gap-3 p-3"
           onclick={toggleSelection.bind(null, id)}
         >
-          <div class="flex items-center gap-3 p-2">
+          <div class="flex items-center gap-3">
             {#if avatarObjectKey === null}
               <DraftAvatar class="size-10" />
             {:else}
@@ -168,13 +175,7 @@
       </li>
     {/each}
   </ul>
-  <div id="selection-progress" class="flex items-center gap-3">
-    <Progress value={selectedIds.length} max={remainingQuota} />
-    <span class="text-sm whitespace-nowrap text-muted-foreground tabular-nums">
-      {selectedIds.length} / {remainingQuota} slots
-    </span>
-  </div>
-  <div class="flex items-center gap-2">
+  <div class="flex items-center gap-2 pt-3">
     <Button type="submit" class="grow" {disabled}>
       {hasExistingSubmission ? 'Update Selection' : 'Submit Selection'}
     </Button>

--- a/src/routes/dashboard/(faculty)/students/rankings-form.svelte
+++ b/src/routes/dashboard/(faculty)/students/rankings-form.svelte
@@ -193,9 +193,11 @@
     {/each}
   </ul>
   <div class="flex items-center gap-2 pt-3">
-    <Button type="submit" class="grow" {disabled}>
-      {hasExistingSubmission ? 'Update Selection' : 'Submit Selection'}
-    </Button>
+    {#if hasExistingSubmission}
+      <Button type="submit" variant="outline" class="grow" {disabled}>Update Selection</Button>
+    {:else}
+      <Button type="submit" class="grow" {disabled}>Submit Selection</Button>
+    {/if}
     <Popover.Root>
       <Popover.Trigger>
         <CircleHelpIcon class="size-4 text-muted-foreground" />

--- a/src/routes/dashboard/+layout.svelte
+++ b/src/routes/dashboard/+layout.svelte
@@ -29,7 +29,7 @@
     <div class="flex h-dvh w-full overflow-hidden">
       <SideBar {user} />
       <div class="flex min-w-0 grow flex-col">
-        <main class="m-4 grow space-y-4 overflow-y-auto">
+        <main class="m-4 flex grow flex-col gap-4 overflow-y-auto">
           {@render children?.()}
         </main>
         <BottomNav />

--- a/tests/draft.test.ts
+++ b/tests/draft.test.ts
@@ -1251,7 +1251,7 @@ test.describe('Draft Lifecycle', () => {
         await ndslHeadPage.goto('/dashboard/students/');
         await expectStatCards(ndslHeadPage, { quota: 2, remaining: 2, drafted: 0 });
         await expectNoPreviousPicks(ndslHeadPage);
-        await expect(ndslHeadPage.locator('#selection-progress')).toContainText('0 / 2 slots');
+        await expect(ndslHeadPage.locator('#selection-progress')).toContainText('0/2 Slots');
         await expect(ndslHeadPage.getByRole('button', { name: 'Submit Selection' })).toBeVisible();
       });
 
@@ -1266,7 +1266,7 @@ test.describe('Draft Lifecycle', () => {
         await ndslHeadPage.getByRole('button', { name: /Eager/u }).click();
         await expect(ndslHeadPage.locator('li[data-selected="true"]')).toHaveCount(1);
         await expect(ndslHeadPage.locator('li[data-selected="true"]')).toContainText(/Eager/u);
-        await expect(ndslHeadPage.locator('#selection-progress')).toHaveText(/1 \/ 2 slots/u);
+        await expect(ndslHeadPage.locator('#selection-progress')).toHaveText(/1\/2 Slots/u);
         ndslHeadPage.on('dialog', dialog => dialog.accept());
         const responsePromise = ndslHeadPage.waitForResponse('/dashboard/students/?/rankings');
         await ndslHeadPage.getByRole('button', { name: 'Submit Selection' }).click();
@@ -1312,7 +1312,7 @@ test.describe('Draft Lifecycle', () => {
 
         // Original saved selection should still be visible after reload
         await expectPreviousPicksTab(ndslHeadPage, 1, [/Partial/u]);
-        await expect(ndslHeadPage.locator('#selection-progress')).toContainText('1 /');
+        await expect(ndslHeadPage.locator('#selection-progress')).toContainText('1/');
       });
 
       test('can edit to empty selection', async ({ ndslHeadPage }) => {
@@ -1320,7 +1320,7 @@ test.describe('Draft Lifecycle', () => {
 
         // Deselect the current pick (Partial from previous test)
         await ndslHeadPage.getByRole('button', { name: /Partial/u }).click();
-        await expect(ndslHeadPage.locator('#selection-progress')).toContainText('0 /');
+        await expect(ndslHeadPage.locator('#selection-progress')).toContainText('0/');
 
         ndslHeadPage.on('dialog', dialog => dialog.accept());
         const responsePromise = ndslHeadPage.waitForResponse('/dashboard/students/?/rankings');
@@ -1379,7 +1379,7 @@ test.describe('Draft Lifecycle', () => {
         await expect(ndslHeadPage.getByRole('button', { name: 'Update Selection' })).toBeVisible();
 
         // Eager should already be selected (from previous test)
-        await expect(ndslHeadPage.locator('#selection-progress')).toContainText('1 /');
+        await expect(ndslHeadPage.locator('#selection-progress')).toContainText('1/');
 
         // Submit without changes
         ndslHeadPage.on('dialog', dialog => dialog.accept());
@@ -1698,7 +1698,7 @@ test.describe('Draft Lifecycle', () => {
       test('before submission: Previous Picks Round 1 with Patient', async ({ cslHeadPage }) => {
         await cslHeadPage.goto('/dashboard/students/');
         await expectStatCards(cslHeadPage, { quota: 2, remaining: 1, drafted: 1 });
-        await expect(cslHeadPage.locator('#selection-progress')).toContainText('0 / 1 slots');
+        await expect(cslHeadPage.locator('#selection-progress')).toContainText('0/1 Slots');
         await expectPreviousPicksTab(cslHeadPage, 1, [
           /Candidate, Patient/u,
           /202012346/u,
@@ -1712,7 +1712,7 @@ test.describe('Draft Lifecycle', () => {
         await cslHeadPage.getByRole('button', { name: /Partial/u }).click();
         await expect(cslHeadPage.locator('li[data-selected="true"]')).toHaveCount(1);
         await expect(cslHeadPage.locator('li[data-selected="true"]')).toContainText(/Partial/u);
-        await expect(cslHeadPage.locator('#selection-progress')).toHaveText(/1 \/ 1 slots/u);
+        await expect(cslHeadPage.locator('#selection-progress')).toHaveText(/1\/1 Slots/u);
         cslHeadPage.on('dialog', dialog => dialog.accept());
         const responsePromise = cslHeadPage.waitForResponse('/dashboard/students/?/rankings');
         await cslHeadPage.getByRole('button', { name: 'Submit Selection' }).click();
@@ -1777,7 +1777,7 @@ test.describe('Draft Lifecycle', () => {
       test('before submission: Previous Picks Round 1 with Eager', async ({ ndslHeadPage }) => {
         await ndslHeadPage.goto('/dashboard/students/');
         await expectStatCards(ndslHeadPage, { quota: 2, remaining: 1, drafted: 1 });
-        await expect(ndslHeadPage.locator('#selection-progress')).toContainText('0 / 1 slots');
+        await expect(ndslHeadPage.locator('#selection-progress')).toContainText('0/1 Slots');
         await expectPreviousPicksTab(ndslHeadPage, 1, [
           /Draftee, Eager/u,
           /202012345/u,
@@ -1791,7 +1791,7 @@ test.describe('Draft Lifecycle', () => {
         await ndslHeadPage.getByRole('button', { name: /Unlucky/u }).click();
         await expect(ndslHeadPage.locator('li[data-selected="true"]')).toHaveCount(1);
         await expect(ndslHeadPage.locator('li[data-selected="true"]')).toContainText(/Unlucky/u);
-        await expect(ndslHeadPage.locator('#selection-progress')).toHaveText(/1 \/ 1 slots/u);
+        await expect(ndslHeadPage.locator('#selection-progress')).toHaveText(/1\/1 Slots/u);
         ndslHeadPage.on('dialog', dialog => dialog.accept());
         const responsePromise = ndslHeadPage.waitForResponse('/dashboard/students/?/rankings');
         await ndslHeadPage.getByRole('button', { name: 'Submit Selection' }).click();

--- a/tests/draft.test.ts
+++ b/tests/draft.test.ts
@@ -36,7 +36,9 @@ async function expectPreviousPicksTab(page: Page, round: number, studentNames: R
 }
 
 async function expectNoPreviousPicks(page: Page) {
-  await expect(page.locator('#previous-picks')).toHaveCount(0);
+  const panel = page.locator('#previous-picks');
+  await expect(panel).toBeVisible();
+  await expect(panel.locator('[data-slot="empty"]')).toBeVisible();
 }
 
 async function expectStudentsCallout(
@@ -49,7 +51,7 @@ async function expectStudentsCallout(
   } = {},
 ) {
   await page.goto('/dashboard/students/');
-  const emptyState = page.locator('[data-slot="empty"]');
+  const emptyState = page.locator('[data-slot="empty"]').filter({ hasText: expected });
   await expect(emptyState).toBeVisible();
   if (typeof options.title !== 'undefined') await expect(emptyState).toContainText(options.title);
   await expect(emptyState).toContainText(expected);


### PR DESCRIPTION
This PR closes #124 by polishing the two-column layout so that it's no longer cramped. On submit, the green "Submit Selection" becomes an outlined "Update Selection" to hint that the submission has been made.

<img width="1605" height="972" alt="new two-column layout featuring two cards for the previous picks and the current round options" src="https://github.com/user-attachments/assets/196d2023-9971-44b8-b5f4-b356facc3638" />