### PR TITLE
chore(ui): add contributor link for Harry

### DIFF
--- a/src/lib/features/contributors/index.svelte
+++ b/src/lib/features/contributors/index.svelte
@@ -44,6 +44,7 @@
       avatar: 'https://avatars.githubusercontent.com/u/87745547',
       roles: { '2026': 'Infrastructure Team: Head' },
       github: 'Harry2166',
+      linkedin: 'harry-quijano',
     },
     {
       name: 'Michael Real',


### PR DESCRIPTION
Add a LinkedIn profile link to the personal contributor entry for Harry in the contributors section of the landing page.

## Test Cases

- [ ] The LinkedIn link for Harry renders correctly and navigates to the expected profile.