### PR TITLE
feat(drafts): present drafts by year

### DIFF
--- a/src/lib/features/drafts/table.svelte
+++ b/src/lib/features/drafts/table.svelte
@@ -75,7 +75,7 @@
   <Table.Body>
     {#each drafts as draft (draft.id)}
       {@const status = getStatus(draft)}
-      <Table.Row>
+      <Table.Row data-draft-id={draft.id}>
         <Table.Cell class="font-mono">{draft.activePeriodStart.getFullYear()}</Table.Cell>
         <Table.Cell>
           <Badge variant={getStatusVariant(status)}>{getStatusLabel(status)}</Badge>

--- a/src/lib/features/drafts/table.svelte
+++ b/src/lib/features/drafts/table.svelte
@@ -8,15 +8,19 @@
 
   import type { Draft } from './types';
 
+  type DraftTableRow = Pick<
+    Draft,
+    'id' | 'currRound' | 'maxRounds' | 'activePeriodStart' | 'activePeriodEnd'
+  >;
   type Status = 'registration' | 'regular' | 'intervention' | 'review' | 'finalized';
 
   interface Props {
-    drafts: Draft[];
+    drafts: DraftTableRow[];
   }
 
   const { drafts }: Props = $props();
 
-  function getStatus(draft: Draft) {
+  function getStatus(draft: DraftTableRow) {
     if (draft.activePeriodEnd !== null) return 'finalized';
     if (draft.currRound === null) return 'review';
     if (draft.currRound === 0) return 'registration';
@@ -60,7 +64,7 @@
 <Table.Root>
   <Table.Header>
     <Table.Row>
-      <Table.Head class="w-20">ID</Table.Head>
+      <Table.Head class="w-20">Draft</Table.Head>
       <Table.Head>Status</Table.Head>
       <Table.Head>Started</Table.Head>
       <Table.Head>Ended</Table.Head>
@@ -72,7 +76,7 @@
     {#each drafts as draft (draft.id)}
       {@const status = getStatus(draft)}
       <Table.Row>
-        <Table.Cell class="font-mono">#{draft.id.toString()}</Table.Cell>
+        <Table.Cell class="font-mono">{draft.activePeriodStart.getFullYear()}</Table.Cell>
         <Table.Cell>
           <Badge variant={getStatusVariant(status)}>{getStatusLabel(status)}</Badge>
           {#if status === 'regular' && draft.currRound !== null}

--- a/src/lib/features/drafts/timeline/index.svelte
+++ b/src/lib/features/drafts/timeline/index.svelte
@@ -66,6 +66,7 @@
     lotteryAggregate,
   }: Props = $props();
   const draftId = $derived(rawDraftId.toString());
+  const draftYear = $derived(draft.activePeriodStart.getFullYear());
 
   // Determine current phase
   const currentPhase = $derived(getDraftPhase(draft));
@@ -118,7 +119,7 @@
   <div class="flex flex-col gap-2 lg:flex-row lg:items-start lg:justify-between">
     <div>
       <h2 class="flex items-center gap-2 text-2xl font-bold">
-        <span>Draft #{draftId.toString()}</span>
+        <span>Draft {draftYear}</span>
         <Badge>{draft.maxRounds} Rounds</Badge>
       </h2>
       <p class="text-muted-foreground">

--- a/src/lib/server/database/drizzle.ts
+++ b/src/lib/server/database/drizzle.ts
@@ -209,15 +209,12 @@ export async function getDrafts(db: DbConnection) {
         id: schema.draft.id,
         currRound: schema.draft.currRound,
         maxRounds: schema.draft.maxRounds,
-        registrationClosedAt: schema.draft.registrationClosedAt,
-        isRegistrationClosed,
         activePeriodStart: sql`lower(${schema.draft.activePeriod})`
           .mapWith(coerceDate)
           .as('_start'),
         activePeriodEnd: sql`upper(${schema.draft.activePeriod})`
           .mapWith(coerceNullableDate)
           .as('_end'),
-        startedAt: schema.draft.startedAt,
       })
       .from(schema.draft)
       .orderBy(({ activePeriodStart }) => sql`${desc(activePeriodStart)} NULLS FIRST`);

--- a/src/lib/server/inngest/functions/send-email/draft-concluded.svelte
+++ b/src/lib/server/inngest/functions/send-email/draft-concluded.svelte
@@ -29,10 +29,11 @@
 
   interface Props {
     draftId: number;
+    draftYear: number;
     lotteryAssignments: LotteryAssignment[];
   }
 
-  const { draftId, lotteryAssignments }: Props = $props();
+  const { draftId, draftYear, lotteryAssignments }: Props = $props();
   const groupedLotteryAssignments = $derived.by(() => {
     // eslint-disable-next-line svelte/prefer-svelte-reactivity -- local grouping container in derived computation
     const grouped = new Map<string, GroupedLotteryAssignment>();
@@ -54,12 +55,12 @@
   });
 </script>
 
-<EmailLayout preview="Draft #{draftId} concluded - Finalize the draft">
+<EmailLayout preview="Draft {draftYear} concluded - Finalize the draft">
   <Section>
     <Section class="p-4">
       <Heading class="text-2xl font-bold text-foreground" as="h1">Draft Concluded</Heading>
       <Text class="text-base">
-        Draft <strong class="text-foreground">#{draftId}</strong> has concluded and the lottery results
+        <strong class="text-foreground">Draft {draftYear}</strong> has concluded and the lottery results
         are ready for review. Please finalize the draft once the assignments below are approved.
       </Text>
     </Section>

--- a/src/lib/server/inngest/functions/send-email/draft-finalization.svelte
+++ b/src/lib/server/inngest/functions/send-email/draft-finalization.svelte
@@ -7,17 +7,18 @@
 
   interface Props {
     draftId: number;
+    draftYear: number;
   }
 
-  const { draftId }: Props = $props();
+  const { draftId, draftYear }: Props = $props();
 </script>
 
-<EmailLayout preview="Draft #{draftId} finalized">
+<EmailLayout preview="Draft {draftYear} finalized">
   <Section>
     <Section class="p-4">
       <Heading class="text-2xl font-bold text-foreground" as="h1">Draft Finalized</Heading>
       <Text class="text-base">
-        Draft <strong class="text-foreground">#{draftId}</strong> has been finalized. Assignments have
+        <strong class="text-foreground">Draft {draftYear}</strong> has been finalized. Assignments have
         been synced.
       </Text>
     </Section>

--- a/src/lib/server/inngest/functions/send-email/lottery-intervened.svelte
+++ b/src/lib/server/inngest/functions/send-email/lottery-intervened.svelte
@@ -8,13 +8,13 @@
     studentEmail: string;
     avatarUrl: string;
     labName: string;
-    draftId: number;
+    draftYear: number;
   }
 
-  const { studentName, studentEmail, avatarUrl, labName, draftId }: Props = $props();
+  const { studentName, studentEmail, avatarUrl, labName, draftYear }: Props = $props();
 </script>
 
-<EmailLayout preview="Manual assignment notification - Draft #{draftId}">
+<EmailLayout preview="Manual assignment notification - Draft {draftYear}">
   <Section>
     <Section class="p-4">
       <Heading class="text-2xl font-bold text-foreground" as="h1"

--- a/src/lib/server/inngest/functions/send-email/round-started.svelte
+++ b/src/lib/server/inngest/functions/send-email/round-started.svelte
@@ -6,17 +6,17 @@
   import EmailLayout from './email-layout.svelte';
 
   interface Props {
-    draftId: number;
+    draftYear: number;
     round: number | null;
   }
 
-  const { draftId, round }: Props = $props();
+  const { draftYear, round }: Props = $props();
 </script>
 
 <EmailLayout
   preview={round === null
-    ? `Lottery round started - Draft #${draftId}`
-    : `Round #${round} started - Draft #${draftId}`}
+    ? `Lottery round started - Draft ${draftYear}`
+    : `Round #${round} started - Draft ${draftYear}`}
 >
   <Section>
     <Section class="p-4">
@@ -30,11 +30,11 @@
       <Text class="text-base">Hello,</Text>
       {#if round === null}
         <Text class="text-base">
-          The <strong>lottery round</strong> for Draft <strong>#{draftId}</strong> has begun.
+          The <strong>lottery round</strong> for <strong>Draft {draftYear}</strong> has begun.
         </Text>
       {:else}
         <Text class="text-base">
-          <strong>Round #{round}</strong> for Draft <strong>#{draftId}</strong> has begun.
+          <strong>Round #{round}</strong> for <strong>Draft {draftYear}</strong> has begun.
         </Text>
       {/if}
     </Section>

--- a/src/lib/server/inngest/functions/send-email/round-submitted.svelte
+++ b/src/lib/server/inngest/functions/send-email/round-submitted.svelte
@@ -6,11 +6,11 @@
   interface Props {
     labName: string;
     round: number;
-    draftId: number;
+    draftYear: number;
     isCreate: boolean;
   }
 
-  const { labName, round, draftId, isCreate }: Props = $props();
+  const { labName, round, draftYear, isCreate }: Props = $props();
 </script>
 
 <EmailLayout
@@ -27,8 +27,8 @@
         The <strong>{labName}</strong>
         {isCreate ? 'has submitted' : 'has updated'}
         their student preferences for
-        <strong>Round #{round}</strong> of Draft
-        <strong>#{draftId}</strong>.
+        <strong>Round #{round}</strong> of
+        <strong>Draft {draftYear}</strong>.
       </Text>
       {#if isCreate}
         <Text class="text-base">

--- a/src/lib/server/inngest/functions/send-email/shared.ts
+++ b/src/lib/server/inngest/functions/send-email/shared.ts
@@ -72,69 +72,76 @@ export async function createEmailMessage(event: RenderableEmailEvent, sender: Se
 
   switch (event.name) {
     case 'draft/round.started.email.batch':
-    case 'draft/round.started.email.fallback':
+    case 'draft/round.started.email.fallback': {
       recipient = event.data.recipientEmail;
       subject =
         event.data.round === null
-          ? `[DRAP] Lottery Round for Draft #${event.data.draftId} has begun!`
-          : `[DRAP] Round #${event.data.round} for Draft #${event.data.draftId} has begun!`;
+          ? `[DRAP] Lottery Round for Draft ${event.data.draftYear} has begun!`
+          : `[DRAP] Round #${event.data.round} for Draft ${event.data.draftYear} has begun!`;
       html = await emailRenderer.render(RoundStarted, {
         props: {
-          draftId: event.data.draftId,
+          draftYear: event.data.draftYear,
           round: event.data.round,
         } satisfies ComponentProps<typeof RoundStarted>,
       });
       break;
+    }
     case 'draft/round.submitted.email.batch':
-    case 'draft/round.submitted.email.fallback':
+    case 'draft/round.submitted.email.fallback': {
       recipient = event.data.recipientEmail;
       subject = event.data.isCreate
-        ? `[DRAP] Acknowledgement from ${event.data.labId.toUpperCase()} for Round #${event.data.round} of Draft #${event.data.draftId}`
-        : `[DRAP] Preference Update from ${event.data.labId.toUpperCase()} for Round #${event.data.round} of Draft #${event.data.draftId}`;
+        ? `[DRAP] Acknowledgement from ${event.data.labId.toUpperCase()} for Round #${event.data.round} of Draft ${event.data.draftYear}`
+        : `[DRAP] Preference Update from ${event.data.labId.toUpperCase()} for Round #${event.data.round} of Draft ${event.data.draftYear}`;
       html = await emailRenderer.render(RoundSubmitted, {
         props: {
           labName: event.data.labName,
           round: event.data.round,
-          draftId: event.data.draftId,
+          draftYear: event.data.draftYear,
           isCreate: event.data.isCreate,
         } satisfies ComponentProps<typeof RoundSubmitted>,
       });
       break;
+    }
     case 'draft/lottery.intervened.email.batch':
-    case 'draft/lottery.intervened.email.fallback':
+    case 'draft/lottery.intervened.email.fallback': {
       recipient = event.data.recipientEmail;
-      subject = `[DRAP] Lottery Intervention for ${event.data.labId.toUpperCase()} in Draft #${event.data.draftId}`;
+      subject = `[DRAP] Lottery Intervention for ${event.data.labId.toUpperCase()} in Draft ${event.data.draftYear}`;
       html = await emailRenderer.render(LotteryIntervened, {
         props: {
           studentName: event.data.studentName,
           studentEmail: event.data.studentEmail,
           avatarUrl: event.data.avatarUrl,
           labName: event.data.labName,
-          draftId: event.data.draftId,
+          draftYear: event.data.draftYear,
         } satisfies ComponentProps<typeof LotteryIntervened>,
       });
       break;
+    }
     case 'draft/draft.concluded.email.batch':
-    case 'draft/draft.concluded.email.fallback':
+    case 'draft/draft.concluded.email.fallback': {
       recipient = event.data.recipientEmail;
-      subject = `[DRAP] Draft #${event.data.draftId} Concluded`;
+      subject = `[DRAP] Draft ${event.data.draftYear} Concluded`;
       html = await emailRenderer.render(DraftConcluded, {
         props: {
           draftId: event.data.draftId,
+          draftYear: event.data.draftYear,
           lotteryAssignments: event.data.lotteryAssignments,
         } satisfies ComponentProps<typeof DraftConcluded>,
       });
       break;
+    }
     case 'draft/draft.finalization.email.batch':
-    case 'draft/draft.finalization.email.fallback':
+    case 'draft/draft.finalization.email.fallback': {
       recipient = event.data.recipientEmail;
-      subject = `[DRAP] Draft #${event.data.draftId} Finalized`;
+      subject = `[DRAP] Draft ${event.data.draftYear} Finalized`;
       html = await emailRenderer.render(DraftFinalization, {
         props: {
           draftId: event.data.draftId,
+          draftYear: event.data.draftYear,
         } satisfies ComponentProps<typeof DraftFinalization>,
       });
       break;
+    }
     case 'draft/user.assigned.email.batch':
     case 'draft/user.assigned.email.fallback':
       recipient = event.data.userEmail;

--- a/src/lib/server/inngest/schema.ts
+++ b/src/lib/server/inngest/schema.ts
@@ -6,6 +6,7 @@ const EmailAttempt = v.optional(v.pipe(v.number(), v.integer(), v.minValue(0)));
 export const RoundStartedBatchEmailEvent = eventType('draft/round.started.email.batch', {
   schema: v.object({
     draftId: v.number(),
+    draftYear: v.number(),
     round: v.nullable(v.number()),
     recipientEmail: v.string(),
     recipientName: v.string(),
@@ -18,6 +19,7 @@ export const RoundStartedFallbackEmailEvent = eventType('draft/round.started.ema
   schema: v.object({
     id: v.string(),
     draftId: v.number(),
+    draftYear: v.number(),
     round: v.nullable(v.number()),
     recipientEmail: v.string(),
     recipientName: v.string(),
@@ -30,6 +32,7 @@ export type RoundStartedFallbackEmailSchema = v.InferOutput<
 export const RoundSubmittedBatchEmailEvent = eventType('draft/round.submitted.email.batch', {
   schema: v.object({
     draftId: v.number(),
+    draftYear: v.number(),
     round: v.number(),
     labId: v.string(),
     labName: v.string(),
@@ -46,6 +49,7 @@ export const RoundSubmittedFallbackEmailEvent = eventType('draft/round.submitted
   schema: v.object({
     id: v.string(),
     draftId: v.number(),
+    draftYear: v.number(),
     round: v.number(),
     labId: v.string(),
     labName: v.string(),
@@ -62,6 +66,7 @@ export const LotteryInterventionBatchEmailEvent = eventType(
   {
     schema: v.object({
       draftId: v.number(),
+      draftYear: v.number(),
       labId: v.string(),
       labName: v.string(),
       studentName: v.string(),
@@ -83,6 +88,7 @@ export const LotteryInterventionFallbackEmailEvent = eventType(
     schema: v.object({
       id: v.string(),
       draftId: v.number(),
+      draftYear: v.number(),
       labId: v.string(),
       labName: v.string(),
       studentName: v.string(),
@@ -100,6 +106,7 @@ export type LotteryInterventionFallbackEmailSchema = v.InferOutput<
 export const DraftConcludedBatchEmailEvent = eventType('draft/draft.concluded.email.batch', {
   schema: v.object({
     draftId: v.number(),
+    draftYear: v.number(),
     recipientEmail: v.string(),
     recipientName: v.string(),
     lotteryAssignments: v.array(
@@ -122,6 +129,7 @@ export const DraftConcludedFallbackEmailEvent = eventType('draft/draft.concluded
   schema: v.object({
     id: v.string(),
     draftId: v.number(),
+    draftYear: v.number(),
     recipientEmail: v.string(),
     recipientName: v.string(),
     lotteryAssignments: v.array(
@@ -142,6 +150,7 @@ export type DraftConcludedFallbackEmailSchema = v.InferOutput<
 export const DraftFinalizationBatchEmailEvent = eventType('draft/draft.finalization.email.batch', {
   schema: v.object({
     draftId: v.number(),
+    draftYear: v.number(),
     recipientEmail: v.string(),
     recipientName: v.string(),
     attempt: EmailAttempt,
@@ -157,6 +166,7 @@ export const DraftFinalizationFallbackEmailEvent = eventType(
     schema: v.object({
       id: v.string(),
       draftId: v.number(),
+      draftYear: v.number(),
       recipientEmail: v.string(),
       recipientName: v.string(),
     }),

--- a/src/routes/(landing)/history/+page.svelte
+++ b/src/routes/(landing)/history/+page.svelte
@@ -22,7 +22,7 @@
         {#if activePeriodEnd !== null}
           <!-- Finalized Draft -->
           {@const end = format(activePeriodEnd, 'PPPpp')}
-          <li>
+          <li data-draft-id={draftId}>
             <a
               href={resolve(`/history/${draftId}/`)}
               class="preset-tonal-muted flex items-center gap-3 rounded-lg border-3 px-4 py-4 transition duration-150 hover:brightness-120 dark:hover:brightness-110"
@@ -37,7 +37,7 @@
           </li>
         {:else if currRound === null}
           <!-- Review Stage -->
-          <li>
+          <li data-draft-id={draftId}>
             <a
               href={resolve(`/history/${draftId}/`)}
               class="preset-tonal-accent flex items-center gap-3 rounded-lg border-3 px-4 py-4 transition duration-150 hover:brightness-115 dark:hover:brightness-110"
@@ -52,7 +52,7 @@
           </li>
         {:else if currRound > maxRounds}
           <!-- Lottery Stage -->
-          <li>
+          <li data-draft-id={draftId}>
             <a
               href={resolve(`/history/${draftId}/`)}
               class="preset-tonal-accent flex items-center gap-3 rounded-lg border-3 px-4 py-4 transition duration-150 hover:brightness-115 dark:hover:brightness-110"
@@ -67,7 +67,7 @@
           </li>
         {:else if currRound === 0}
           <!-- Registration Stage -->
-          <li>
+          <li data-draft-id={draftId}>
             <a
               href={resolve(`/history/${draftId}/`)}
               class="preset-tonal-secondary flex items-center gap-3 rounded-lg border-3 px-4 py-4 transition duration-150 hover:brightness-115 dark:hover:brightness-110"
@@ -82,7 +82,7 @@
           </li>
         {:else}
           <!-- Regular Draft Process -->
-          <li>
+          <li data-draft-id={draftId}>
             <a
               href={resolve(`/history/${draftId}/`)}
               class="preset-tonal-primary flex items-center gap-3 rounded-lg border-3 px-4 py-4 transition duration-150 hover:brightness-120 dark:hover:brightness-110"

--- a/src/routes/(landing)/history/+page.svelte
+++ b/src/routes/(landing)/history/+page.svelte
@@ -17,6 +17,7 @@
   <nav id="history-draft-list">
     <ul class="space-y-2">
       {#each drafts as { id: draftId, activePeriodStart, activePeriodEnd, currRound, maxRounds } (draftId)}
+        {@const draftYear = activePeriodStart.getFullYear()}
         {@const start = format(activePeriodStart, 'PPPpp')}
         {#if activePeriodEnd !== null}
           <!-- Finalized Draft -->
@@ -28,7 +29,7 @@
             >
               <CheckCircleIcon class="size-8" />
               <span
-                ><strong>Draft #{draftId}</strong> was held from
+                ><strong>Draft {draftYear}</strong> was held from
                 <time datetime={activePeriodStart.toISOString()}>{start}</time> –
                 <time datetime={activePeriodEnd.toISOString()}>{end}</time> over {maxRounds} rounds.</span
               >
@@ -43,7 +44,7 @@
             >
               <SparklesIcon class="size-8" />
               <span
-                ><strong>Draft #{draftId}</strong> started on
+                ><strong>Draft {draftYear}</strong> started on
                 <time datetime={activePeriodStart.toISOString()}>{start}</time> and is now in the review
                 stage after lottery assignment.</span
               >
@@ -58,7 +59,7 @@
             >
               <SparklesIcon class="size-8" />
               <span
-                ><strong>Draft #{draftId}</strong> started on
+                ><strong>Draft {draftYear}</strong> started on
                 <time datetime={activePeriodStart.toISOString()}>{start}</time> and is now in the
                 lottery stage after {maxRounds} regular rounds.</span
               >
@@ -73,7 +74,7 @@
             >
               <ClockIcon class="size-8" />
               <span
-                ><strong>Draft #{draftId}</strong> started on
+                ><strong>Draft {draftYear}</strong> started on
                 <time datetime={activePeriodStart.toISOString()}>{start}</time> and is currently waiting
                 for students to register.</span
               >
@@ -88,7 +89,7 @@
             >
               <ScaleIcon class="size-8" />
               <span
-                ><strong>Draft #{draftId}</strong> started on
+                ><strong>Draft {draftYear}</strong> started on
                 <time datetime={activePeriodStart.toISOString()}>{start}</time>
                 and is currently in Round {currRound}/{maxRounds} in the regular draft process.</span
               >

--- a/src/routes/(landing)/history/[draft]/+page.server.ts
+++ b/src/routes/(landing)/history/[draft]/+page.server.ts
@@ -1,9 +1,11 @@
-import { and, asc, desc, eq, isNotNull, isNull, lte, or } from 'drizzle-orm';
+import { and, asc, desc, eq, isNotNull, isNull, lte, or, sql } from 'drizzle-orm';
 import { error } from '@sveltejs/kit';
 
 import * as schema from '$lib/server/database/schema';
+import { assertOptional } from '$lib/server/assert';
+import { coerceDate, coerceNullableDate } from '$lib/coerce';
 import { db } from '$lib/server/database';
-import { type DbConnection, getDraftById } from '$lib/server/database/drizzle';
+import type { DbConnection } from '$lib/server/database/drizzle';
 import { Logger } from '$lib/server/telemetry/logger';
 import { Tracer } from '$lib/server/telemetry/tracer';
 import { validateBigInt } from '$lib/validators';
@@ -24,7 +26,7 @@ export async function load({ params: { draft: id } }) {
 
     logger.debug('fetching draft', { 'draft.id': draftId.toString() });
 
-    const draft = await getDraftById(db, draftId);
+    const draft = await getHistoryDraftById(db, draftId);
     if (typeof draft === 'undefined') {
       logger.fatal('draft not found');
       error(404, 'Draft not found.');
@@ -33,13 +35,28 @@ export async function load({ params: { draft: id } }) {
     logger.debug('draft fetched', {
       'draft.round.current': draft.currRound,
       'draft.round.max': draft.maxRounds,
-      'draft.registration.closes_at': draft.registrationClosedAt.toISOString(),
     });
 
     const events = await getDraftEvents(db, draftId);
     logger.debug('draft events fetched', { 'draft.event_count': events.length });
 
-    return { draftId, draft, events };
+    return { draft, events };
+  });
+}
+
+async function getHistoryDraftById(db: DbConnection, id: bigint) {
+  return await tracer.asyncSpan('get-history-draft-by-id', async span => {
+    span.setAttribute('database.draft.id', id.toString());
+    return await db
+      .select({
+        currRound: schema.draft.currRound,
+        maxRounds: schema.draft.maxRounds,
+        activePeriodStart: sql`lower(${schema.draft.activePeriod})`.mapWith(coerceDate),
+        activePeriodEnd: sql`upper(${schema.draft.activePeriod})`.mapWith(coerceNullableDate),
+      })
+      .from(schema.draft)
+      .where(eq(schema.draft.id, id))
+      .then(assertOptional);
   });
 }
 

--- a/src/routes/(landing)/history/[draft]/+page.svelte
+++ b/src/routes/(landing)/history/[draft]/+page.svelte
@@ -20,7 +20,6 @@
 
   const { data } = $props();
   const {
-    draftId,
     draft: { currRound, maxRounds, activePeriodStart, activePeriodEnd },
     events,
   } = $derived(data);
@@ -105,6 +104,7 @@
   );
 
   const startDateTime = $derived(format(activePeriodStart, 'PPPpp'));
+  const draftYear = $derived(activePeriodStart.getFullYear());
   const startIsoString = $derived(activePeriodStart.toISOString());
   const end = $derived(
     activePeriodEnd === null
@@ -119,7 +119,7 @@
 <div class="mb-4 flex items-center gap-2 text-xl">
   <Link href={resolve('/history/')} class="no-underline">Draft History</Link>
   <ChevronRightIcon class="size-4" />
-  <span class="font-semibold">Draft #{draftId}</span>
+  <span class="font-semibold">Draft {draftYear}</span>
 </div>
 {#if end !== null}
   {@const { endIsoString, endDateTime } = end}
@@ -204,14 +204,14 @@
               <li class="preset-tonal-primary rounded-lg border px-3 py-1.5">
                 <div class="flex items-center gap-3">
                   <CheckIcon class="size-4" />
-                  <span class="flex-auto">Draft #{draftId} was finalized.</span>
+                  <span class="flex-auto">Draft {draftYear} was finalized.</span>
                 </div>
               </li>
             {:else if entry.type === 'draft-created'}
               <li class="preset-tonal-success rounded-lg border px-3 py-1.5">
                 <div class="flex items-center gap-3">
                   <PlayIcon class="size-4" />
-                  <span>Draft #{draftId} was created.</span>
+                  <span>Draft {draftYear} was created.</span>
                 </div>
               </li>
             {:else}

--- a/src/routes/dashboard/(draft)/drafts/[draftId]/+page.server.ts
+++ b/src/routes/dashboard/(draft)/drafts/[draftId]/+page.server.ts
@@ -304,7 +304,7 @@ export const actions = {
 
       const draftId = BigInt(draft);
       const roundsToNotify: (number | null)[] = [];
-      await db.transaction(
+      const draftYear = await db.transaction(
         async db => {
           const activeDraft = await getDraftByIdForUpdate(db, draftId);
           if (typeof activeDraft === 'undefined' || activeDraft.activePeriodEnd !== null) {
@@ -348,6 +348,8 @@ export const actions = {
               break;
             }
           }
+
+          return activeDraft.activePeriodStart.getFullYear();
         },
         { isolationLevel: 'read committed' },
       );
@@ -359,6 +361,7 @@ export const actions = {
           facultyAndStaff.map(({ email, givenName, familyName }) =>
             RoundStartedBatchEmailEvent.create({
               draftId: Number(draftId),
+              draftYear,
               round,
               recipientEmail: email,
               recipientName: `${givenName} ${familyName}`,
@@ -515,7 +518,7 @@ export const actions = {
       }
 
       logger.debug('intervening draft with pairs', { 'draft.pair_count': pairs.length });
-      const result = await db.transaction(
+      const { result, draftYear } = await db.transaction(
         async db => {
           const activeDraft = await getDraftByIdForUpdate(db, draftId);
 
@@ -551,7 +554,10 @@ export const actions = {
             error(400);
           }
 
-          return await insertLotteryChoices(db, draftId, user.id, pairs, 'intervention');
+          return {
+            result: await insertLotteryChoices(db, draftId, user.id, pairs, 'intervention'),
+            draftYear: activeDraft.activePeriodStart.getFullYear(),
+          };
         },
         { isolationLevel: 'read committed' },
       );
@@ -572,6 +578,7 @@ export const actions = {
           facultyAndStaff.map(({ email, givenName, familyName }) =>
             LotteryInterventionBatchEmailEvent.create({
               draftId: Number(draftId),
+              draftYear,
               labId,
               labName,
               studentName: `${student.givenName} ${student.familyName}`,
@@ -620,8 +627,9 @@ export const actions = {
       const draftId = BigInt(draft);
       logger.debug('running lottery and entering review', { 'draft.id': draft });
 
+      let draftYear: number;
       try {
-        await db.transaction(
+        draftYear = await db.transaction(
           async db => {
             const activeDraft = await getDraftByIdForUpdate(db, draftId);
             if (typeof activeDraft === 'undefined' || activeDraft.activePeriodEnd !== null) {
@@ -683,10 +691,11 @@ export const actions = {
               logger.fatal('draft must exist prior to entering review');
               error(404);
             }
+
+            return activeDraft.activePeriodStart.getFullYear();
           },
           { isolationLevel: 'read committed' },
         );
-        logger.info('draft review started');
       } catch (err) {
         if (err === ZIP_NOT_EQUAL) {
           logger.fatal('cannot conclude draft because schedule and quota mismatched');
@@ -694,6 +703,8 @@ export const actions = {
         }
         throw err;
       }
+
+      logger.info('draft review started');
 
       const [draftAdmins, assignments] = await Promise.all([
         getDraftAdmins(db),
@@ -714,6 +725,7 @@ export const actions = {
         draftAdmins.map(({ email, givenName, familyName }) =>
           DraftConcludedBatchEmailEvent.create({
             draftId: Number(draftId),
+            draftYear,
             recipientEmail: email,
             recipientName: `${givenName} ${familyName}`,
             lotteryAssignments,
@@ -755,7 +767,7 @@ export const actions = {
       logger.debug('finalizing draft', { 'draft.id': draft });
 
       let userAssignments: { userId: string; labId: string }[] = [];
-      await db.transaction(
+      const draftYear = await db.transaction(
         async db => {
           const activeDraft = await getDraftByIdForUpdate(db, draftId);
 
@@ -783,6 +795,8 @@ export const actions = {
           const results = await syncResultsToUsers(db, draftId);
           logger.debug('draft results synced', { 'draft.result_count': results.length });
           userAssignments = results;
+
+          return activeDraft.activePeriodStart.getFullYear();
         },
         { isolationLevel: 'read committed' },
       );
@@ -792,6 +806,7 @@ export const actions = {
         facultyAndStaff.map(({ email, givenName, familyName }) =>
           DraftFinalizationBatchEmailEvent.create({
             draftId: Number(draftId),
+            draftYear,
             recipientEmail: email,
             recipientName: `${givenName} ${familyName}`,
           }),

--- a/src/routes/dashboard/(draft)/labs/+page.svelte
+++ b/src/routes/dashboard/(draft)/labs/+page.svelte
@@ -11,20 +11,21 @@
 
 <div class="space-y-4">
   {#if typeof draft !== 'undefined'}
-    {@const { id: draftId, activePeriodStart } = draft}
+    {@const { activePeriodStart } = draft}
+    {@const draftYear = activePeriodStart.getFullYear()}
     {@const startDate = format(activePeriodStart, 'PPP')}
     {@const startTime = format(activePeriodStart, 'pp')}
     {#if isRegistrationActive}
       <Callout variant="destructive">
         <span
-          ><strong>Draft #{draftId}</strong> registration is ongoing. The lab catalog is locked to prevent
+          ><strong>Draft {draftYear}</strong> registration is ongoing. The lab catalog is locked to prevent
           inconsistencies while students are submitting their rankings.</span
         >
       </Callout>
     {:else}
       <Callout variant="warning">
         <span
-          ><strong>Draft #{draftId}</strong> started last <strong>{startDate}</strong> at
+          ><strong>Draft {draftYear}</strong> started last <strong>{startDate}</strong> at
           <strong>{startTime}</strong>. Changes on this page only affect the lab catalog and will
           not be reflected in the currently active draft.</span
         >

--- a/src/routes/dashboard/(faculty)/+layout.svelte
+++ b/src/routes/dashboard/(faculty)/+layout.svelte
@@ -5,16 +5,10 @@
 
   const { data, children } = $props();
   const {
-    draft: {
-      id,
-      currRound,
-      maxRounds,
-      registrationClosedAt,
-      activePeriodStart,
-      isRegistrationClosed,
-    },
+    draft: { currRound, maxRounds, registrationClosedAt, activePeriodStart, isRegistrationClosed },
   } = $derived(data);
   const startDate = $derived(format(activePeriodStart, 'PPP'));
+  const draftYear = $derived(activePeriodStart.getFullYear());
   const startTime = $derived(format(activePeriodStart, 'pp'));
   const closeDate = $derived(format(registrationClosedAt, 'PPP'));
   const closeTime = $derived(format(registrationClosedAt, 'pp'));
@@ -24,15 +18,15 @@
   <Alert.Description class="prose max-w-none dark:prose-invert">
     <p>
       {#if currRound === null}
-        <strong>Draft #{id}</strong> (which opened last <strong>{startDate}</strong> at
+        <strong>Draft {draftYear}</strong> (which opened last <strong>{startDate}</strong> at
         <strong>{startTime}</strong>) has completed lottery assignment and is now under review by
         the draft administrators.
       {:else if currRound > maxRounds}
-        <strong>Draft #{id}</strong> (which opened last <strong>{startDate}</strong> at
+        <strong>Draft {draftYear}</strong> (which opened last <strong>{startDate}</strong> at
         <strong>{startTime}</strong>) has recently finished the main drafting process. It is
         currently in the lottery round.
       {:else}
-        <strong>Draft #{id}</strong> is currently on Round <strong>{currRound}</strong>
+        <strong>Draft {draftYear}</strong> is currently on Round <strong>{currRound}</strong>
         of <strong>{maxRounds}</strong>. It opened last <strong>{startDate}</strong> at
         <strong>{startTime}</strong>.
         {#if currRound === 0 && !isRegistrationClosed}

--- a/src/routes/dashboard/(faculty)/students/+page.server.ts
+++ b/src/routes/dashboard/(faculty)/students/+page.server.ts
@@ -162,7 +162,7 @@ export const actions = {
 
       const draftId = BigInt(draft);
       try {
-        const { submittedRound, roundsToNotify, isCreate } = await db.transaction(
+        const { submittedRound, roundsToNotify, isCreate, draftYear } = await db.transaction(
           async db => {
             const activeDraft = await getDraftByIdForUpdate(db, draftId);
             if (typeof activeDraft === 'undefined' || activeDraft.activePeriodEnd !== null) {
@@ -330,6 +330,7 @@ export const actions = {
               submittedRound,
               roundsToNotify,
               isCreate: typeof existingChoice === 'undefined',
+              draftYear: activeDraft.activePeriodStart.getFullYear(),
             };
           },
           { isolationLevel: 'read committed' },
@@ -350,6 +351,7 @@ export const actions = {
         const roundSubmittedEvents = Array.from(initialRecipients, email =>
           RoundSubmittedBatchEmailEvent.create({
             draftId: Number(draftId),
+            draftYear,
             round: submittedRound,
             labId: lab,
             labName,
@@ -362,6 +364,7 @@ export const actions = {
           facultyAndStaff.map(({ email, givenName, familyName }) =>
             RoundStartedBatchEmailEvent.create({
               draftId: Number(draftId),
+              draftYear,
               round,
               recipientEmail: email,
               recipientName: `${givenName} ${familyName}`,

--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -310,9 +310,14 @@ export const actions = {
             logger.info('dispatching email event...');
             switch (parsed.event) {
               case 'draft/round.started.email.batch': {
+                const draftYear = await getDraftYear(db, parsed.draftId);
+                if (typeof draftYear === 'undefined') {
+                  logger.fatal('unknown draft id', void 0, { 'draft.id': parsed.draftId });
+                  return fail(404, { message: 'Draft is not found in the database.' });
+                }
+
                 let givenName: string;
                 let familyName: string;
-
                 try {
                   ({ givenName, familyName } = await getUserNameByEmail(db, parsed.recipientEmail));
                 } catch (err) {
@@ -326,7 +331,7 @@ export const actions = {
                 await inngest.send(
                   RoundStartedBatchEmailEvent.create({
                     draftId: parsed.draftId,
-                    draftYear: await getDraftYear(db, parsed.draftId),
+                    draftYear,
                     round: parsed.round,
                     recipientEmail: parsed.recipientEmail,
                     recipientName: `${givenName} ${familyName}`,
@@ -335,8 +340,13 @@ export const actions = {
                 break;
               }
               case 'draft/round.submitted.email.batch': {
-                let labName: string;
+                const draftYear = await getDraftYear(db, parsed.draftId);
+                if (typeof draftYear === 'undefined') {
+                  logger.fatal('unknown draft id', void 0, { 'draft.id': parsed.draftId });
+                  return fail(404, { message: 'Draft is not found in the database.' });
+                }
 
+                let labName: string;
                 try {
                   ({ name: labName } = await getLabById(db, parsed.labId));
                 } catch (err) {
@@ -350,7 +360,7 @@ export const actions = {
                 await inngest.send(
                   RoundSubmittedBatchEmailEvent.create({
                     draftId: parsed.draftId,
-                    draftYear: await getDraftYear(db, parsed.draftId),
+                    draftYear,
                     round: parsed.round,
                     labId: parsed.labId,
                     labName,
@@ -361,6 +371,12 @@ export const actions = {
                 break;
               }
               case 'draft/lottery.intervened.email.batch': {
+                const draftYear = await getDraftYear(db, parsed.draftId);
+                if (typeof draftYear === 'undefined') {
+                  logger.fatal('unknown draft id', void 0, { 'draft.id': parsed.draftId });
+                  return fail(404, { message: 'Draft is not found in the database.' });
+                }
+
                 let labName: string;
                 try {
                   ({ name: labName } = await getLabById(db, parsed.labId));
@@ -409,7 +425,7 @@ export const actions = {
                 await inngest.send(
                   LotteryInterventionBatchEmailEvent.create({
                     draftId: parsed.draftId,
-                    draftYear: await getDraftYear(db, parsed.draftId),
+                    draftYear,
                     labId: parsed.labId,
                     labName,
                     studentName: `${studentGivenName} ${studentFamilyName}`,
@@ -422,9 +438,14 @@ export const actions = {
                 break;
               }
               case 'draft/draft.concluded.email.batch': {
+                const draftYear = await getDraftYear(db, parsed.draftId);
+                if (typeof draftYear === 'undefined') {
+                  logger.fatal('unknown draft id', void 0, { 'draft.id': parsed.draftId });
+                  return fail(404, { message: 'Draft is not found in the database.' });
+                }
+
                 let givenName: string;
                 let familyName: string;
-
                 try {
                   ({ givenName, familyName } = await getUserNameByEmail(db, parsed.recipientEmail));
                 } catch (err) {
@@ -484,7 +505,7 @@ export const actions = {
                 await inngest.send(
                   DraftConcludedBatchEmailEvent.create({
                     draftId: parsed.draftId,
-                    draftYear: await getDraftYear(db, parsed.draftId),
+                    draftYear,
                     recipientEmail: parsed.recipientEmail,
                     recipientName: `${givenName} ${familyName}`,
                     lotteryAssignments,
@@ -493,9 +514,14 @@ export const actions = {
                 break;
               }
               case 'draft/draft.finalization.email.batch': {
+                const draftYear = await getDraftYear(db, parsed.draftId);
+                if (typeof draftYear === 'undefined') {
+                  logger.fatal('unknown draft id', void 0, { 'draft.id': parsed.draftId });
+                  return fail(404, { message: 'Draft is not found in the database.' });
+                }
+
                 let givenName: string;
                 let familyName: string;
-
                 try {
                   ({ givenName, familyName } = await getUserNameByEmail(db, parsed.recipientEmail));
                 } catch (err) {
@@ -509,7 +535,7 @@ export const actions = {
                 await inngest.send(
                   DraftFinalizationBatchEmailEvent.create({
                     draftId: parsed.draftId,
-                    draftYear: await getDraftYear(db, parsed.draftId),
+                    draftYear,
                     recipientEmail: parsed.recipientEmail,
                     recipientName: `${givenName} ${familyName}`,
                   }),
@@ -663,7 +689,7 @@ async function getUserNameByEmail(db: DbConnection, email: string) {
 async function getDraftYear(db: DbConnection, draftId: number) {
   return await tracer.asyncSpan('get-draft-year', async span => {
     span.setAttribute('database.draft.id', draftId);
-    const { draftYear } = await db
+    const draft = await db
       .select({
         draftYear: sql`extract(year from lower(${schema.draft.activePeriod}))`.mapWith(
           coerceNumber,
@@ -671,9 +697,9 @@ async function getDraftYear(db: DbConnection, draftId: number) {
       })
       .from(schema.draft)
       .where(eq(schema.draft.id, BigInt(draftId)))
-      .then(assertSingle);
+      .then(assertOptional);
 
-    return draftYear;
+    return draft?.draftYear;
   });
 }
 

--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -8,6 +8,7 @@ import { error, fail, redirect } from '@sveltejs/kit';
 
 import * as schema from '$lib/server/database/schema';
 import { assertOptional, assertSingle } from '$lib/server/assert';
+import { coerceNumber } from '$lib/coerce';
 import { db } from '$lib/server/database';
 import {
   type DbConnection,
@@ -321,9 +322,11 @@ export const actions = {
                   }
                   throw err;
                 }
+
                 await inngest.send(
                   RoundStartedBatchEmailEvent.create({
                     draftId: parsed.draftId,
+                    draftYear: await getDraftYear(db, parsed.draftId),
                     round: parsed.round,
                     recipientEmail: parsed.recipientEmail,
                     recipientName: `${givenName} ${familyName}`,
@@ -333,6 +336,7 @@ export const actions = {
               }
               case 'draft/round.submitted.email.batch': {
                 let labName: string;
+
                 try {
                   ({ name: labName } = await getLabById(db, parsed.labId));
                 } catch (err) {
@@ -342,9 +346,11 @@ export const actions = {
                   }
                   throw err;
                 }
+
                 await inngest.send(
                   RoundSubmittedBatchEmailEvent.create({
                     draftId: parsed.draftId,
+                    draftYear: await getDraftYear(db, parsed.draftId),
                     round: parsed.round,
                     labId: parsed.labId,
                     labName,
@@ -403,6 +409,7 @@ export const actions = {
                 await inngest.send(
                   LotteryInterventionBatchEmailEvent.create({
                     draftId: parsed.draftId,
+                    draftYear: await getDraftYear(db, parsed.draftId),
                     labId: parsed.labId,
                     labName,
                     studentName: `${studentGivenName} ${studentFamilyName}`,
@@ -477,6 +484,7 @@ export const actions = {
                 await inngest.send(
                   DraftConcludedBatchEmailEvent.create({
                     draftId: parsed.draftId,
+                    draftYear: await getDraftYear(db, parsed.draftId),
                     recipientEmail: parsed.recipientEmail,
                     recipientName: `${givenName} ${familyName}`,
                     lotteryAssignments,
@@ -497,9 +505,11 @@ export const actions = {
                   }
                   throw err;
                 }
+
                 await inngest.send(
                   DraftFinalizationBatchEmailEvent.create({
                     draftId: parsed.draftId,
+                    draftYear: await getDraftYear(db, parsed.draftId),
                     recipientEmail: parsed.recipientEmail,
                     recipientName: `${givenName} ${familyName}`,
                   }),
@@ -647,6 +657,23 @@ async function getUserNameByEmail(db: DbConnection, email: string) {
       .from(schema.user)
       .where(eq(schema.user.email, email))
       .then(assertSingle);
+  });
+}
+
+async function getDraftYear(db: DbConnection, draftId: number) {
+  return await tracer.asyncSpan('get-draft-year', async span => {
+    span.setAttribute('database.draft.id', draftId);
+    const { draftYear } = await db
+      .select({
+        draftYear: sql`extract(year from lower(${schema.draft.activePeriod}))`.mapWith(
+          coerceNumber,
+        ),
+      })
+      .from(schema.draft)
+      .where(eq(schema.draft.id, BigInt(draftId)))
+      .then(assertSingle);
+
+    return draftYear;
   });
 }
 

--- a/src/routes/dashboard/lab/+page.svelte
+++ b/src/routes/dashboard/lab/+page.svelte
@@ -57,11 +57,12 @@
         {#each membersByDraft as { draftId, memberUsers } (draftId)}
           {@const draft = drafts.find(draft => Number(draft.id) === draftId)}
           {#if typeof draft !== 'undefined'}
+            {@const draftYear = draft.activePeriodStart.getFullYear()}
             {@const start = format(draft.activePeriodStart, 'PPPpp')}
             <Accordion.Item value="draft-{draftId}">
               <Accordion.Trigger>
                 <div class="flex flex-col items-start text-left">
-                  <span class="text-lg font-semibold">Draft {draftId}</span>
+                  <span class="text-lg font-semibold">Draft {draftYear}</span>
                   <small class="text-muted-foreground">
                     {#if draft.activePeriodEnd === null}
                       Ongoing since <time datetime={draft.activePeriodStart.toISOString()}

--- a/src/routes/dashboard/lab/+page.svelte
+++ b/src/routes/dashboard/lab/+page.svelte
@@ -59,8 +59,8 @@
           {#if typeof draft !== 'undefined'}
             {@const draftYear = draft.activePeriodStart.getFullYear()}
             {@const start = format(draft.activePeriodStart, 'PPPpp')}
-            <Accordion.Item value="draft-{draftId}">
-              <Accordion.Trigger>
+            <Accordion.Item value="draft-{draftId}" data-draft-id={draftId}>
+              <Accordion.Trigger data-draft-id={draftId}>
                 <div class="flex flex-col items-start text-left">
                   <span class="text-lg font-semibold">Draft {draftYear}</span>
                   <small class="text-muted-foreground">

--- a/src/routes/dashboard/student/+page.server.ts
+++ b/src/routes/dashboard/student/+page.server.ts
@@ -9,7 +9,6 @@ import { MaxBufferError } from 'get-stream';
 
 import * as schema from '$lib/server/database/schema';
 import { assertOptional, assertSingle } from '$lib/server/assert';
-import { coerceDate, coerceNullableDate } from '$lib/coerce';
 import { db } from '$lib/server/database';
 import {
   type DbConnection,
@@ -407,8 +406,6 @@ async function getDraftByIdForShare(db: DrizzleTransaction, id: bigint) {
         maxRounds: schema.draft.maxRounds,
         registrationClosedAt: schema.draft.registrationClosedAt,
         isRegistrationClosed,
-        activePeriodStart: sql`lower(${schema.draft.activePeriod})`.mapWith(coerceDate),
-        activePeriodEnd: sql`upper(${schema.draft.activePeriod})`.mapWith(coerceNullableDate),
       })
       .from(schema.draft)
       .where(eq(schema.draft.id, id))

--- a/tests/draft.test.ts
+++ b/tests/draft.test.ts
@@ -3,6 +3,20 @@ import { expect, type Locator, type Page } from '@playwright/test';
 
 import { test } from './fixtures/users';
 
+const draftYearPattern = /Draft \d{4}/u;
+
+function getDraftRow(page: Page, draftId: string) {
+  return page.locator(`tr[data-draft-id="${draftId}"]`);
+}
+
+function getHistoryDraft(page: Page, draftId: string) {
+  return page.locator(`#history-draft-list [data-draft-id="${draftId}"]`);
+}
+
+function getDraftAccordionTrigger(page: Page, draftId: string) {
+  return page.locator(`button[data-draft-id="${draftId}"]`);
+}
+
 async function assertLogout(page: Page) {
   await page.goto('/dashboard/');
   await page.getByRole('button', { name: 'Logout' }).click();
@@ -645,7 +659,7 @@ test.describe('Draft Lifecycle', () => {
       const responseData = await response.json();
       expect(responseData.type).toBe('success');
       await expect(dialog).not.toBeVisible();
-      await expect(adminPage.getByText(/#\d+/u)).toBeVisible();
+      await expect(getDraftRow(adminPage, '1').locator('td').first()).toHaveText(/\d{4}/u);
       await expect(adminPage.getByText('Registration')).toBeVisible();
     });
   });
@@ -793,13 +807,13 @@ test.describe('Draft Lifecycle', () => {
   });
 
   test.describe('History During Registration', () => {
-    test('shows Draft #1 in registration phase', async ({ page }) => {
+    test('shows draft year in registration phase', async ({ page }) => {
       await page.goto('/history/');
-      await expect(page.getByText('Draft #1')).toBeVisible();
+      await expect(getHistoryDraft(page, '1')).toContainText(draftYearPattern);
       await expect(page.getByText('currently waiting for students to register')).toBeVisible();
     });
 
-    test.describe('Draft #1 detail page', () => {
+    test.describe('first draft detail page', () => {
       test('shows registration status', async ({ page }) => {
         await page.goto('/history/1/');
         await expect(page.getByText('registration stage')).toBeVisible();
@@ -809,7 +823,7 @@ test.describe('Draft Lifecycle', () => {
         await page.goto('/history/1/');
         const items = page.locator('section > ol.border-s > li.ms-6 ol.space-y-1 > li');
         await expect(items).toHaveCount(1);
-        await expect(items.first()).toContainText('Draft #1 was created.');
+        await expect(items.first()).toContainText(/Draft \d{4} was created\./u);
       });
     });
   });
@@ -1902,9 +1916,9 @@ test.describe('Draft Lifecycle', () => {
   });
 
   test.describe('History During Lottery', () => {
-    test('shows Draft #1 in lottery phase', async ({ page }) => {
+    test('shows draft year in lottery phase', async ({ page }) => {
       await page.goto('/history/');
-      await expect(page.getByText('Draft #1')).toBeVisible();
+      await expect(getHistoryDraft(page, '1')).toContainText(draftYearPattern);
       await expect(page.getByText(/lottery stage/u)).toBeVisible();
     });
 
@@ -2512,14 +2526,14 @@ test.describe('Draft Lifecycle', () => {
   });
 
   test.describe('History After Finalization', () => {
-    test('shows Draft #1 as finalized', async ({ page }) => {
+    test('shows draft year as finalized', async ({ page }) => {
       await page.goto('/history/');
-      await expect(page.getByText('Draft #1')).toBeVisible();
+      await expect(getHistoryDraft(page, '1')).toContainText(draftYearPattern);
       await expect(page.getByText(/was held from/u)).toBeVisible();
       await expect(page.getByText(/over 3 rounds/u)).toBeVisible();
     });
 
-    test.describe('Draft #1 detail timeline', () => {
+    test.describe('first draft detail timeline', () => {
       test('shows finalized status banner', async ({ page }) => {
         await page.goto('/history/1/');
         await expect(page.getByText(/was held from/u)).toBeVisible();
@@ -2642,7 +2656,7 @@ test.describe('Draft Lifecycle', () => {
   test.describe('Drafts Table Final State', () => {
     test('shows draft with finalized status', async ({ adminPage }) => {
       await adminPage.goto('/dashboard/drafts/');
-      await expect(adminPage.getByText('#1')).toBeVisible();
+      await expect(getDraftRow(adminPage, '1').locator('td').first()).toHaveText(/\d{4}/u);
       await expect(adminPage.getByText('Finalized')).toBeVisible();
     });
   });
@@ -2711,21 +2725,21 @@ test.describe('Draft Lifecycle', () => {
     test('NDSL sees 2 assigned students (Eager, Unlucky)', async ({ ndslHeadPage }) => {
       await ndslHeadPage.goto('/dashboard/lab/');
       // Expand the draft accordion to reveal members
-      await ndslHeadPage.getByRole('button', { name: /Draft 1/u }).click();
+      await getDraftAccordionTrigger(ndslHeadPage, '1').click();
       await expect(ndslHeadPage.getByText(/Eager/u)).toBeVisible();
       await expect(ndslHeadPage.getByText(/Unlucky/u)).toBeVisible();
     });
 
     test('CSL sees 2 assigned students (Patient, PartialToDrafted)', async ({ cslHeadPage }) => {
       await cslHeadPage.goto('/dashboard/lab/');
-      await cslHeadPage.getByRole('button', { name: /Draft 1/u }).click();
+      await getDraftAccordionTrigger(cslHeadPage, '1').click();
       await expect(cslHeadPage.getByText(/Patient/u)).toBeVisible();
       await expect(cslHeadPage.getByText(/Partial/u)).toBeVisible();
     });
   });
 
   test.describe('Second Draft — Archive And Setup', () => {
-    test.describe('ACL archival before Draft #2', () => {
+    test.describe('ACL archival before second draft', () => {
       test('archives ACL', async ({ adminPage }) => {
         await adminPage.goto('/dashboard/labs/');
 
@@ -2748,7 +2762,7 @@ test.describe('Draft Lifecycle', () => {
       });
     });
 
-    test('creates Draft #2 with 2 rounds', async ({ adminPage }) => {
+    test('creates second draft with 2 rounds', async ({ adminPage }) => {
       await adminPage.goto('/dashboard/drafts/');
       await adminPage.getByRole('button', { name: 'Create Draft' }).click();
 
@@ -2768,7 +2782,7 @@ test.describe('Draft Lifecycle', () => {
       const responseData = await response.json();
       expect(responseData.type).toBe('success');
 
-      await expect(adminPage.getByText('#2')).toBeVisible();
+      await expect(getDraftRow(adminPage, '2').locator('td').first()).toHaveText(/\d{4}/u);
       await expect(adminPage.getByText('Registration')).toBeVisible();
     });
 
@@ -2941,20 +2955,20 @@ test.describe('Draft Lifecycle', () => {
   });
 
   test.describe('Second Draft — History During Registration', () => {
-    test('history shows Draft #2 in registration phase', async ({ page }) => {
+    test('history shows draft year in registration phase', async ({ page }) => {
       await page.goto('/history/');
-      await expect(page.getByText('Draft #2')).toBeVisible();
+      await expect(getHistoryDraft(page, '2')).toContainText(draftYearPattern);
       await expect(page.getByText('currently waiting for students to register')).toBeVisible();
     });
 
-    test('Draft #2 detail shows registration status', async ({ page }) => {
+    test('second draft detail shows registration status', async ({ page }) => {
       await page.goto('/history/2/');
       await expect(page.getByText('registration stage')).toBeVisible();
     });
   });
 
   test.describe('Second Draft — Regular Flow (No Lottery Assignments)', () => {
-    test('updates Draft #2 initial snapshots before start', async ({ adminPage }) => {
+    test('updates second draft initial snapshots before start', async ({ adminPage }) => {
       await adminPage.goto('/dashboard/drafts/2/');
       await expect(adminPage.getByText('Registered Students', { exact: true })).toBeVisible();
       await expect(adminPage.getByText('Current Draft Participants')).toBeVisible();
@@ -2976,7 +2990,7 @@ test.describe('Draft Lifecycle', () => {
       expect(responseData.type).toBe('success');
     });
 
-    test('starts Draft #2', async ({ adminPage }) => {
+    test('starts second draft', async ({ adminPage }) => {
       await adminPage.goto('/dashboard/drafts/2/');
       await expect(adminPage.getByText('Registered Students', { exact: true })).toBeVisible();
       await expect(adminPage.getByText('Current Draft Participants')).toBeVisible();
@@ -2992,7 +3006,7 @@ test.describe('Draft Lifecycle', () => {
       await expect(adminPage.getByText(/Round 1/u).first()).toBeVisible();
     });
 
-    test('Draft #2 round-1 auto-acks show correct callouts', async ({
+    test('second draft round-1 auto-acks show correct callouts', async ({
       sclHeadPage,
       cvmilHeadPage,
     }) => {
@@ -3012,7 +3026,7 @@ test.describe('Draft Lifecycle', () => {
       await expect(aclHeadPage.getByText('Lab Excluded from This Draft')).toBeVisible();
     });
 
-    test('archives CSL while Draft #2 is active', async ({ adminPage }) => {
+    test('archives CSL while second draft is active', async ({ adminPage }) => {
       await adminPage.goto('/dashboard/labs/');
 
       const cslRow = adminPage
@@ -3077,12 +3091,12 @@ test.describe('Draft Lifecycle', () => {
       );
     });
 
-    test('Draft #2 reaches Round 2', async ({ adminPage }) => {
+    test('second draft reaches Round 2', async ({ adminPage }) => {
       await adminPage.goto('/dashboard/drafts/2/');
       await expect(adminPage.getByText(/Round 2/u).first()).toBeVisible();
     });
 
-    test('Draft #2 round-2 auto-acks show correct callouts', async ({
+    test('second draft round-2 auto-acks show correct callouts', async ({
       cvmilHeadPage,
       ndslHeadPage,
       cslHeadPage,
@@ -3145,7 +3159,7 @@ test.describe('Draft Lifecycle', () => {
   });
 
   test.describe('Second Draft — Lottery And Finalization', () => {
-    test('sets lottery snapshots to zero for Draft #2', async ({ adminPage }) => {
+    test('sets lottery snapshots to zero for second draft', async ({ adminPage }) => {
       await adminPage.goto('/dashboard/drafts/2/');
       await expect(adminPage.locator('main')).toBeVisible();
       await adminPage.getByRole('button', { name: 'Edit Lottery Quota' }).click();
@@ -3166,7 +3180,7 @@ test.describe('Draft Lifecycle', () => {
       }
     });
 
-    test('runs lottery for Draft #2', async ({ adminPage }) => {
+    test('runs lottery for second draft', async ({ adminPage }) => {
       await adminPage.goto('/dashboard/drafts/2/');
 
       adminPage.on('dialog', dialog => dialog.accept());
@@ -3178,7 +3192,7 @@ test.describe('Draft Lifecycle', () => {
       expect(concludeResponseData.type).toBe('success');
     });
 
-    test('enters review phase with finalize action for Draft #2', async ({ adminPage }) => {
+    test('enters review phase with finalize action for second draft', async ({ adminPage }) => {
       await adminPage.goto('/dashboard/drafts/2/');
       await expect(adminPage.getByText(/Started .* · Review/u)).toBeVisible();
       await expect(adminPage.getByRole('heading', { name: 'Review Phase' })).toHaveCount(0);
@@ -3187,7 +3201,7 @@ test.describe('Draft Lifecycle', () => {
       await expect(adminPage.getByRole('button', { name: 'Finalize Draft' })).toBeVisible();
     });
 
-    test('finalizes Draft #2', async ({ adminPage }) => {
+    test('finalizes second draft', async ({ adminPage }) => {
       await adminPage.goto('/dashboard/drafts/2/');
       adminPage.on('dialog', dialog => dialog.accept());
 
@@ -3200,7 +3214,7 @@ test.describe('Draft Lifecycle', () => {
   });
 
   test.describe('Second Draft — Dashboard And History Verification', () => {
-    test('admin finalized breakdown is correct for Draft #2', async ({ adminPage }) => {
+    test('admin finalized breakdown is correct for second draft', async ({ adminPage }) => {
       await adminPage.goto('/dashboard/drafts/2/');
 
       await expect(adminPage.locator('#stat-total-students')).toHaveText('3');
@@ -3224,7 +3238,9 @@ test.describe('Draft Lifecycle', () => {
       );
     });
 
-    test('keeps lottery results sheet available in finalized Draft #1', async ({ adminPage }) => {
+    test('keeps lottery results sheet available in finalized first draft', async ({
+      adminPage,
+    }) => {
       await adminPage.goto('/dashboard/drafts/1/');
       await adminPage.getByRole('button', { name: 'Lottery' }).click();
 
@@ -3240,10 +3256,10 @@ test.describe('Draft Lifecycle', () => {
     });
 
     test.describe('drafts table and history', () => {
-      test('drafts table lists Draft #2 and Draft #1', async ({ adminPage }) => {
+      test('drafts table lists draft years', async ({ adminPage }) => {
         await adminPage.goto('/dashboard/drafts/');
-        await expect(adminPage.getByText('#2')).toBeVisible();
-        await expect(adminPage.getByText('#1')).toBeVisible();
+        await expect(getDraftRow(adminPage, '1').locator('td').first()).toHaveText(/\d{4}/u);
+        await expect(getDraftRow(adminPage, '2').locator('td').first()).toHaveText(/\d{4}/u);
       });
 
       test('drafts table shows both drafts as finalized', async ({ adminPage }) => {
@@ -3251,19 +3267,19 @@ test.describe('Draft Lifecycle', () => {
         await expect(adminPage.getByText('Finalized')).toHaveCount(2);
       });
 
-      test('history index reflects Draft #2 2-round finalization', async ({ page }) => {
+      test('history index reflects second draft 2-round finalization', async ({ page }) => {
         await page.goto('/history/');
-        await expect(page.getByText('Draft #2')).toBeVisible();
+        await expect(getHistoryDraft(page, '2')).toContainText(draftYearPattern);
         await expect(page.getByText(/over 2 rounds/u)).toBeVisible();
       });
 
-      test('Draft #2 detail shows finalized status', async ({ page }) => {
+      test('second draft detail shows finalized status', async ({ page }) => {
         await page.goto('/history/2/');
         await expect(page.getByText(/was held from/u)).toBeVisible();
         await expect(page.getByText(/over 2 rounds/u)).toBeVisible();
       });
 
-      test('Draft #2 detail timeline has round ordering without lottery events', async ({
+      test('second draft detail timeline has round ordering without lottery events', async ({
         page,
       }) => {
         await page.goto('/history/2/');
@@ -3292,7 +3308,7 @@ test.describe('Draft Lifecycle', () => {
   });
 
   test.describe('Second Draft — Archived Lab Read Models', () => {
-    test('CSL appears in archived labs after Draft #2 finalization', async ({ adminPage }) => {
+    test('CSL appears in archived labs after second draft finalization', async ({ adminPage }) => {
       await adminPage.goto('/dashboard/labs/');
       await adminPage.getByRole('tab', { name: /Archived Labs/u }).click();
       await expect(adminPage.getByText('Computer Security Laboratory')).toBeVisible();
@@ -3337,22 +3353,22 @@ test.describe('Draft Lifecycle', () => {
       ).toBeVisible();
     });
 
-    test.describe('Draft #2 faculty views', () => {
+    test.describe('second draft faculty views', () => {
       test('NDSL head can view assignees', async ({ ndslHeadPage }) => {
         await ndslHeadPage.goto('/dashboard/lab/');
-        await ndslHeadPage.getByRole('button', { name: /Draft 2/u }).click();
+        await getDraftAccordionTrigger(ndslHeadPage, '2').click();
         await expect(ndslHeadPage.getByText(/SecondNdsl/u)).toBeVisible();
       });
 
       test('CSL head can view assignees', async ({ cslHeadPage }) => {
         await cslHeadPage.goto('/dashboard/lab/');
-        await cslHeadPage.getByRole('button', { name: /Draft 2/u }).click();
+        await getDraftAccordionTrigger(cslHeadPage, '2').click();
         await expect(cslHeadPage.getByText(/SecondCsl/u)).toBeVisible();
       });
 
       test('SCL head can view assignees', async ({ sclHeadPage }) => {
         await sclHeadPage.goto('/dashboard/lab/');
-        await sclHeadPage.getByRole('button', { name: /Draft 2/u }).click();
+        await getDraftAccordionTrigger(sclHeadPage, '2').click();
         await expect(sclHeadPage.getByText(/SecondScl/u)).toBeVisible();
       });
     });
@@ -3369,7 +3385,7 @@ test.describe('Draft Lifecycle', () => {
 
     test.describe('Closed Registration', () => {
       test.describe('Allowlist', () => {
-        test('creates Draft #3 with a past registration close', async ({ adminPage }) => {
+        test('creates third draft with a past registration close', async ({ adminPage }) => {
           await adminPage.goto('/dashboard/drafts/');
           await adminPage.getByRole('button', { name: 'Create Draft' }).click();
 
@@ -3502,7 +3518,7 @@ test.describe('Draft Lifecycle', () => {
     });
 
     test.describe('Zero Quota Flow', () => {
-      test('starts Draft #3 and reaches interventions through the regular flow', async ({
+      test('starts third draft and reaches interventions through the regular flow', async ({
         adminPage,
       }) => {
         await adminPage.goto(draftDetailPath());
@@ -3520,7 +3536,7 @@ test.describe('Draft Lifecycle', () => {
         await expect(adminPage.getByRole('heading', { name: 'Interventions' })).toBeVisible();
       });
 
-      test('runs lottery for Draft #3 with zero quota', async ({ adminPage }) => {
+      test('runs lottery for third draft with zero quota', async ({ adminPage }) => {
         await adminPage.goto(draftDetailPath());
         adminPage.on('dialog', dialog => dialog.accept());
 
@@ -3536,7 +3552,7 @@ test.describe('Draft Lifecycle', () => {
         await expect(adminPage.getByRole('button', { name: 'Finalize Draft' })).toBeVisible();
       });
 
-      test('finalizes Draft #3 with zero assignments', async ({ adminPage }) => {
+      test('finalizes third draft with zero assignments', async ({ adminPage }) => {
         await adminPage.goto(draftDetailPath());
         adminPage.on('dialog', dialog => dialog.accept());
 


### PR DESCRIPTION
This updates draft presentation across the app to use the draft year instead of the draft ID, while preserving draft IDs for routing, keys, event identity, and stable test selectors. Draft labels now render as `Draft {YEAR}` in history views, draft tables, lab/faculty surfaces, timelines, and draft-related email content.

The email event contract now carries the presented draft year directly on the draft-related batch and fallback events. This keeps email rendering deterministic without needing to refetch draft metadata while rendering messages.

## Implementation Notes

### Draft Presentation

- Replaced visible `Draft #{id}` labels with year-based draft labels derived from each draft's active period start.
- Kept `draft.id` in URLs, keyed iterations, event payload identity, and test hooks.
- Added `data-draft-id` hooks to draft rows, history entries, and lab accordion controls so tests can target draft identity without asserting ID-based presentation text.

### Email Events and Templates

- Added required `draftYear` fields to draft-related Inngest email event schemas:
  - round started
  - round submitted
  - lottery intervention
  - draft concluded
  - draft finalization
- Updated email subjects, previews, and body copy to use `Draft {draftYear}` instead of `Draft #{draftId}`.
- Preserved `draftId` where templates still need links back to draft detail pages.
- Dev email dispatch resolves `draftYear` from `draftId` before sending events using `extract(year from lower(active_period))`, and returns a form failure when the draft row does not exist.

### Load Data Cleanup

- Narrowed history detail draft loading to the fields used by that page instead of using the broader draft helper.
- Removed unused active-period data from server load results where the presentation no longer needs it.

### Test Selectors

- Updated Playwright tests to locate drafts by `data-draft-id` and assert year-format presentation instead of depending on `Draft #{id}` text.
- Removed current-year-derived draft label assertions from E2E coverage while leaving unrelated future/past date setup logic intact.

## Breaking Changes

Draft-related email event schemas now require `draftYear`. Producers for the affected app flows and dev email tools have been updated to include this value before dispatching events.

Consumers that emit these events outside the updated producers must add `draftYear` to their payloads. The field is intentionally required because email rendering now treats the presentation year as event data.

## Test Cases

- [ ] Create a draft and confirm the admin drafts table shows the draft year while row identity remains selectable by draft ID.
- [ ] Review `/history/` and `/history/{draftId}/` across registration, lottery/review, and finalized phases to confirm visible labels use `Draft {YEAR}`.
- [ ] Send or preview draft-related email events and confirm subjects/previews/body copy use `Draft {YEAR}` while links still route by draft ID.
- [ ] Use dev email dispatch with an unknown draft ID and confirm it returns the expected form failure instead of throwing.
- [ ] Run the draft lifecycle E2E path and confirm draft-specific assertions use stable `data-draft-id` selectors.
