### PR TITLE
chore(app): update contact email in privacy policy

### DIFF
--- a/src/routes/(landing)/privacy/+page.svelte
+++ b/src/routes/(landing)/privacy/+page.svelte
@@ -90,7 +90,7 @@
       <br />
       <span><Link href="tel:+89818500">(02) 8981 8500</Link> loc. 3231</span>
       <br />
-      <Link href="mailto:info@dcs.upd.edu.ph">info@dcs.upd.edu.ph</Link>
+      <Link href="mailto:dcs.upd@up.edu.ph">dcs.upd@up.edu.ph</Link>
       <br />
     </address>
     <p>


### PR DESCRIPTION
Update the contact email address listed in the Privacy Policy page as requested by the IT administrator.
## Implementation Notes
Single-line change in `src/routes/(landing)/privacy/+page.svelte` — replaced the old contact email with the new one in both the `mailto:` href and the displayed link text.
## Test Cases
- [ ] Navigate to the Privacy Policy page and verify the new email is displayed and linked correctly.
- [ ] Click the email link and confirm it opens the default mail client with the correct recipient.