### PR TITLE
fix(db): use `sql.raw` on `sql.join`ing with commas

### DIFF
--- a/src/lib/server/database/drizzle.ts
+++ b/src/lib/server/database/drizzle.ts
@@ -559,7 +559,7 @@ export async function seedGmailThreadsById(
         thread =>
           sql`(${thread.id}::bigint, ${thread.gmailThreadId}, ${sql.param(thread.gmailMessageIds, schema.gmailThread.gmailMessageIds)}::text[])`,
       ),
-      ',',
+      sql.raw(','),
     );
     const thread = alias(schema.gmailThread, 'thread');
     return await db
@@ -594,7 +594,7 @@ export async function appendGmailThreadsMessageIdsById(
         thread =>
           sql`(${thread.id}::bigint, ${sql.param(thread.gmailMessageIds, schema.gmailThread.gmailMessageIds)}::text[])`,
       ),
-      ',',
+      sql.raw(','),
     );
     const thread = alias(schema.gmailThread, 'thread');
     return await db


### PR DESCRIPTION
This PR fixes a bug in #289 where `sql.join` was called with a plain JavaScript string `','` as the separator instead of `sql.raw(',')`. Without `sql.raw`, Drizzle wraps the comma in parameterized SQL, producing incorrect query syntax in the `seedGmailThreadsById` and `appendGmailThreadsMessageIdsById` functions.

## Test Cases

- [ ] `seedGmailThreadsById` inserts threads correctly with comma-separated values
- [ ] `appendGmailThreadsMessageIdsById` appends message IDs correctly
- [ ] Existing unit and E2E tests pass