### PR TITLE
feat(prod): add Databasus PostgreSQL backup service

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,6 +1,10 @@
 # Production overrides (observability, Drizzle, backup service, production credentials).
 
 services:
+  postgres:
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?required}
+
   databasus:
     pull_policy: build
     build: ./docker/databasus
@@ -18,12 +22,26 @@ services:
       test:
         - 'CMD'
         - '/httpget'
-        - 'http://127.0.0.1:4005/api/v1/system/health'
+        - 'http://localhost:4005/api/v1/system/health'
       interval: 30s
       timeout: 3s
       retries: 3
       start_period: 30s
       start_interval: 1s
+
+  o2:
+    environment:
+      ZO_ROOT_USER_EMAIL: ${ZO_ROOT_USER_EMAIL:?required}
+      ZO_ROOT_USER_PASSWORD: ${ZO_ROOT_USER_PASSWORD:?required}
+
+  rustfs:
+    environment:
+      RUSTFS_ACCESS_KEY: ${S3_ACCESS_KEY:?required}
+      RUSTFS_SECRET_KEY: ${S3_SECRET_KEY:?required}
+
+  setup-bucket:
+    environment:
+      MC_HOST_drap: http://${S3_ACCESS_KEY:?required}:${S3_SECRET_KEY:?required}@rustfs:9000
 
   drizzle-gateway:
     image: ghcr.io/drizzle-team/gateway:1.3.0
@@ -42,24 +60,6 @@ services:
     networks:
       - database
     restart: always
-
-  o2:
-    environment:
-      ZO_ROOT_USER_EMAIL: ${ZO_ROOT_USER_EMAIL:?required}
-      ZO_ROOT_USER_PASSWORD: ${ZO_ROOT_USER_PASSWORD:?required}
-
-  postgres:
-    environment:
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?required}
-
-  rustfs:
-    environment:
-      RUSTFS_ACCESS_KEY: ${S3_ACCESS_KEY:?required}
-      RUSTFS_SECRET_KEY: ${S3_SECRET_KEY:?required}
-
-  setup-bucket:
-    environment:
-      MC_HOST_drap: http://${S3_ACCESS_KEY:?required}:${S3_SECRET_KEY:?required}@rustfs:9000
 
 volumes:
   databasus-data:

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,23 +1,29 @@
-# Production overrides (observability, Drizzle, production credentials).
+# Production overrides (observability, Drizzle, backup service, production credentials).
 
 services:
-  postgres:
-    environment:
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?required}
-
-  o2:
-    environment:
-      ZO_ROOT_USER_EMAIL: ${ZO_ROOT_USER_EMAIL:?required}
-      ZO_ROOT_USER_PASSWORD: ${ZO_ROOT_USER_PASSWORD:?required}
-
-  rustfs:
-    environment:
-      RUSTFS_ACCESS_KEY: ${S3_ACCESS_KEY:?required}
-      RUSTFS_SECRET_KEY: ${S3_SECRET_KEY:?required}
-
-  setup-bucket:
-    environment:
-      MC_HOST_drap: http://${S3_ACCESS_KEY:?required}:${S3_SECRET_KEY:?required}@rustfs:9000
+  databasus:
+    pull_policy: build
+    build: ./docker/databasus
+    ports:
+      - host_ip: 127.0.0.1
+        published: 4005
+        target: 4005
+        protocol: tcp
+    volumes:
+      - databasus-data:/databasus-data
+    networks:
+      - database
+    restart: always
+    healthcheck:
+      test:
+        - 'CMD'
+        - '/httpget'
+        - 'http://127.0.0.1:4005/api/v1/system/health'
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 30s
+      start_interval: 1s
 
   drizzle-gateway:
     image: ghcr.io/drizzle-team/gateway:1.3.0
@@ -37,5 +43,24 @@ services:
       - database
     restart: always
 
+  o2:
+    environment:
+      ZO_ROOT_USER_EMAIL: ${ZO_ROOT_USER_EMAIL:?required}
+      ZO_ROOT_USER_PASSWORD: ${ZO_ROOT_USER_PASSWORD:?required}
+
+  postgres:
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?required}
+
+  rustfs:
+    environment:
+      RUSTFS_ACCESS_KEY: ${S3_ACCESS_KEY:?required}
+      RUSTFS_SECRET_KEY: ${S3_SECRET_KEY:?required}
+
+  setup-bucket:
+    environment:
+      MC_HOST_drap: http://${S3_ACCESS_KEY:?required}:${S3_SECRET_KEY:?required}@rustfs:9000
+
 volumes:
+  databasus-data:
   drizzle-gateway:

--- a/docker/databasus/Dockerfile
+++ b/docker/databasus/Dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/cryptaliagy/httpget:0.1.23 AS httpget
+
+FROM databasus/databasus:v3.45.0
+
+COPY --from=httpget /httpget /httpget


### PR DESCRIPTION
Add Databasus (databasus/databasus:v3.45.0) as a production-only backup service for PostgreSQL. It runs alongside the prod stack, configured on the `database` network so it can reach `postgres` for scheduled backups.

The image is extended with the `/httpget` healthcheck binary (matching the existing pattern used by `o2`). The health endpoint is verified at `/api/v1/system/health` before the service is considered ready.

## Implementation Notes

- Follows the same pattern as `drizzle-gateway` — prod-only infrastructure defined exclusively in `compose.prod.yaml`. Dev and CI stacks are unaffected.
- Custom `docker/databasus/Dockerfile` copies `/httpget` from `ghcr.io/cryptaliagy/httpget:0.1.23`, identical to `docker/openobserve/Dockerfile`.
- Named volume `databasus-data` used for persistence (not a bind mount).

## Test Cases

- [ ] `docker compose -f compose.yaml -f compose.prod.yaml up databasus` starts successfully and healthcheck passes
- [ ] `pnpm docker:dev` does NOT start databasus (dev isolation)
- [ ] `pnpm docker:dev:ci` does NOT start databasus (CI isolation)