### PR TITLE
fix(inngest): cast event ts parameter to timestamptz in session cleanup

### DIFF
--- a/src/lib/server/inngest/functions/cleanup-sessions/index.js
+++ b/src/lib/server/inngest/functions/cleanup-sessions/index.js
@@ -25,7 +25,7 @@ export const cleanupSessions = inngest.createFunction(
           const now = new Date(event.ts);
           const { rowCount } = await db
             .delete(session)
-            .where(lt(session.expiredAt, sql`${now} - interval '30 days'`));
+            .where(lt(session.expiredAt, sql`${now}::timestamptz - interval '30 days'`));
           logger.info('sessions cleaned up', { count: rowCount });
           return rowCount;
         }),


### PR DESCRIPTION
Fix a PostgreSQL type error in the cleanup-sessions Inngest function where a `Date` parameter bound to a prepared statement was implicitly typed as `text`, causing `text - interval '30 days'` to fail with `operator does not exist: timestamp with time zone < interval`.

The fix adds an explicit `::timestamptz` cast so the event timestamp is correctly interpreted as a `timestamptz` before the interval subtraction.

## Test Cases

- [ ] Session cleanup cron runs without the `operator does not exist: timestamp with time zone < interval` error
- [ ] Sessions with `expired_at` older than 30 days before the event timestamp are deleted
- [ ] Sessions with `expired_at` newer than 30 days before the event timestamp are preserved